### PR TITLE
Adding support for DNS over TLS (DOT) & Some bug fixes

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -33,6 +33,16 @@ func TestDOH(t *testing.T) {
 	require.True(t, len(d.A) > 0)
 }
 
+func TestDOT(t *testing.T) {
+	client := New([]string{"dot:dns.google:853", "dot:1dot1dot1dot1.cloudflare-dns.com"}, 5)
+
+	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
+	require.Nil(t, err)
+
+	// From current dig result
+	require.True(t, len(d.A) > 0)
+}
+
 func TestQueryMultiple(t *testing.T) {
 	client := New([]string{"8.8.8.8:53", "1.1.1.1:53"}, 5)
 

--- a/client_test.go
+++ b/client_test.go
@@ -23,6 +23,26 @@ func TestConsistentResolve(t *testing.T) {
 	}
 }
 
+func TestUDP(t *testing.T) {
+	client := New([]string{"1.1.1.1:53", "udp:8.8.8.8"}, 5)
+
+	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
+	require.Nil(t, err)
+
+	// From current dig result
+	require.True(t, len(d.A) > 0)
+}
+
+func TestTCP(t *testing.T) {
+	client := New([]string{"tcp:1.1.1.1:53", "tcp:8.8.8.8"}, 5)
+
+	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
+	require.Nil(t, err)
+
+	// From current dig result
+	require.True(t, len(d.A) > 0)
+}
+
 func TestDOH(t *testing.T) {
 	client := New([]string{"doh:https://doh.opendns.com/dns-query:post", "doh:https://doh.opendns.com/dns-query:get"}, 5)
 

--- a/doh/doh_client.go
+++ b/doh/doh_client.go
@@ -18,11 +18,11 @@ type Client struct {
 }
 
 func NewWithOptions(options Options) *Client {
-	return &Client{DefaultResolver: options.DefaultResolver, httpClient: options.httpClient}
+	return &Client{DefaultResolver: options.DefaultResolver, httpClient: options.HttpClient}
 }
 
 func New() *Client {
-	return NewWithOptions(Options{DefaultResolver: Cloudflare, httpClient: retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle)})
+	return NewWithOptions(Options{DefaultResolver: Cloudflare, HttpClient: retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle)})
 }
 
 func (c *Client) Query(name string, question QuestionType) (*Response, error) {

--- a/doh/options.go
+++ b/doh/options.go
@@ -9,7 +9,7 @@ import (
 
 type Options struct {
 	DefaultResolver Resolver
-	httpClient      *retryablehttp.Client
+	HttpClient      *retryablehttp.Client
 }
 
 type Resolver struct {


### PR DESCRIPTION
Hi there,

[miekg/dns](https://nicedoc.io/miekg/dns) has built-in support for DNS over TLS (DOT), we should add this feature to `retryabledns` so other tools like `dnsx` could benefit from this. Here is an example of using DOT with `retryabledns` now:

```
client := retryabledns.New([]string{"dot:dns.google:853", "dot:1dot1dot1dot1.cloudflare-dns.com"}, 5)

d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
```

This pull request also contains some bug fixes & other minor improvements.
