### PR TITLE
Add SRV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func main() {
     log.Println(ips)
 
     // Query Types: dns.TypeA, dns.TypeNS, dns.TypeCNAME, dns.TypeSOA, dns.TypePTR, dns.TypeMX
-    // dns.TypeTXT, dns.TypeAAAA (from github.com/miekg/dns)
+    // dns.TypeTXT, dns.TypeAAAA, dns.TypeSRV (from github.com/miekg/dns)
     dnsResponses, err := dnsClient.Query(hostname, dns.TypeA)
     if err != nil {
         log.Fatal(err)

--- a/client.go
+++ b/client.go
@@ -179,6 +179,11 @@ func (c *Client) TXT(host string) (*DNSData, error) {
 	return c.QueryMultiple(host, []uint16{dns.TypeTXT})
 }
 
+// SRV helper function
+func (c *Client) SRV(host string) (*DNSData, error) {
+	return c.QueryMultiple(host, []uint16{dns.TypeSRV})
+}
+
 // PTR helper function
 func (c *Client) PTR(host string) (*DNSData, error) {
 	return c.QueryMultiple(host, []uint16{dns.TypePTR})
@@ -521,6 +526,7 @@ type DNSData struct {
 	SOA            []string   `json:"soa,omitempty"`
 	NS             []string   `json:"ns,omitempty"`
 	TXT            []string   `json:"txt,omitempty"`
+	SRV            []string   `json:"srv,omitempty"`
 	CAA            []string   `json:"caa,omitempty"`
 	AllRecords     []string   `json:"all,omitempty"`
 	Raw            string     `json:"raw,omitempty"`
@@ -565,6 +571,8 @@ func (d *DNSData) ParseFromRR(rrs []dns.RR) error {
 			for _, txt := range recordType.Txt {
 				d.TXT = append(d.TXT, trimChars(txt))
 			}
+		case *dns.SRV:
+			d.SRV = append(d.SRV, trimChars(recordType.Target))
 		case *dns.AAAA:
 			if CheckInternalIPs && internalRangeCheckerInstance.ContainsIPv6(recordType.AAAA) {
 				d.HasInternalIPs = true
@@ -596,7 +604,7 @@ func (d *DNSData) ParseFromEnvelopeChan(envChan chan *dns.Envelope) error {
 }
 
 func (d *DNSData) contains() bool {
-	return len(d.A) > 0 || len(d.AAAA) > 0 || len(d.CNAME) > 0 || len(d.MX) > 0 || len(d.NS) > 0 || len(d.PTR) > 0 || len(d.TXT) > 0 || len(d.SOA) > 0 || len(d.CAA) > 0
+	return len(d.A) > 0 || len(d.AAAA) > 0 || len(d.CNAME) > 0 || len(d.MX) > 0 || len(d.NS) > 0 || len(d.PTR) > 0 || len(d.TXT) > 0 || len(d.SRV) > 0 || len(d.SOA) > 0 || len(d.CAA) > 0
 }
 
 // JSON returns the object as json string
@@ -619,6 +627,7 @@ func (d *DNSData) dedupe() {
 	d.SOA = sliceutil.Dedupe(d.SOA)
 	d.NS = sliceutil.Dedupe(d.NS)
 	d.TXT = sliceutil.Dedupe(d.TXT)
+	d.SRV = sliceutil.Dedupe(d.SRV)
 	d.CAA = sliceutil.Dedupe(d.CAA)
 	d.AllRecords = sliceutil.Dedupe(d.AllRecords)
 }


### PR DESCRIPTION
This PR adds support for querying SRV records.

Close https://github.com/projectdiscovery/retryabledns/issues/70

Example:
```
$> dig +short _xmpp-client._tcp.google.com. SRV

20 0 5222 alt1.xmpp.l.google.com.
20 0 5222 alt2.xmpp.l.google.com.
20 0 5222 alt3.xmpp.l.google.com.
5 0 5222 xmpp.l.google.com.
20 0 5222 alt4.xmpp.l.google.com.
```