### PR TITLE
Check length of BaseResolvers to prevent division by zero

### DIFF
--- a/options.go
+++ b/options.go
@@ -16,5 +16,9 @@ func (options *Options) Validate() error {
 	if options.MaxRetries == 0 {
 		return errors.New("retries must be at least 1")
 	}
+
+	if len(options.BaseResolvers) == 0 {
+		return errors.New("resolvers list must not be empty")
+	}
 	return nil
 }

--- a/options.go
+++ b/options.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+var (
+	ErrMaxRetriesZero = errors.New("retries must be at least 1")
+	ErrResolversEmpty = errors.New("resolvers list must not be empty")
+)
+
 type Options struct {
 	BaseResolvers []string
 	MaxRetries    int
@@ -14,11 +19,11 @@ type Options struct {
 
 func (options *Options) Validate() error {
 	if options.MaxRetries == 0 {
-		return errors.New("retries must be at least 1")
+		return ErrMaxRetriesZero
 	}
 
 	if len(options.BaseResolvers) == 0 {
-		return errors.New("resolvers list must not be empty")
+		return ErrResolversEmpty
 	}
 	return nil
 }

--- a/options_test.go
+++ b/options_test.go
@@ -7,7 +7,26 @@ import (
 )
 
 func TestValidateOptions(t *testing.T) {
-	options := Options{}
-	err := options.Validate()
-	require.NotNil(t, err)
+	t.Run("empty options", func(t *testing.T) {
+		options := Options{}
+		err := options.Validate()
+		require.NotNil(t, err)
+	})
+
+	t.Run("max retries errors with zero", func(t *testing.T) {
+		options := Options{
+			MaxRetries: 0,
+		}
+		err := options.Validate()
+		require.ErrorIs(t, err, ErrMaxRetriesZero)
+	})
+
+	t.Run("base resolvers errors if empty", func(t *testing.T) {
+		options := Options{
+			MaxRetries:    1,
+			BaseResolvers: []string{},
+		}
+		err := options.Validate()
+		require.ErrorIs(t, err, ErrResolversEmpty)
+	})
 }


### PR DESCRIPTION
I noticed that when nuclei is supplied with an empty resolver list file (`-r` option), it panics:
```
panic: runtime error: integer divide by zero

goroutine 112869 [running]:
github.com/projectdiscovery/retryabledns.(*Client).Do(0xc0038e2c80, 0x1?)
	/root/go/pkg/mod/github.com/projectdiscovery/retryabledns@v1.0.20/client.go:113 +0x2ee
github.com/projectdiscovery/nuclei/v2/pkg/protocols/dns.(*Request).ExecuteWithResults(0xc000040f00, 0xc0040c7f80, 0xc00406fc50, 0x7fcd0cf4bf18?, 0xc003932198)
	/root/go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.8.9/pkg/protocols/dns/request.go:93 +0x79c
github.com/projectdiscovery/nuclei/v2/pkg/templates.(*ClusterExecuter).Execute(0xc004ec4a80, 0xc0040c7f00)
	/root/go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.8.9/pkg/templates/cluster.go:245 +0x22d
github.com/projectdiscovery/nuclei/v2/pkg/core.(*Engine).executeTemplateWithTargets.func2.1(0x76c406?, 0x0?, 0xc0040c7d00)
	/root/go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.8.9/pkg/core/executors.go:130 +0x296
created by github.com/projectdiscovery/nuclei/v2/pkg/core.(*Engine).executeTemplateWithTargets.func2
	/root/go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.8.9/pkg/core/executors.go:107 +0x4f8
```

The panic is caused by this line: https://github.com/projectdiscovery/retryabledns/blob/main/client.go#L113
Modulo operator is ran with 0 when `c.resolvers` is empty.

I added a check for BaseResolvers' length to prevent it from panicking.

Related - https://github.com/projectdiscovery/nuclei/discussions/2515

