### PR TITLE
add SOA support

### DIFF
--- a/client.go
+++ b/client.go
@@ -530,7 +530,7 @@ type DNSData struct {
 	MX             []string   `json:"mx,omitempty"`
 	PTR            []string   `json:"ptr,omitempty"`
 	ANY            []string   `json:"any,omitempty"`
-	SOA            []string   `json:"soa,omitempty"`
+	SOA            SOA        `json:"soa,omitempty"`
 	NS             []string   `json:"ns,omitempty"`
 	TXT            []string   `json:"txt,omitempty"`
 	SRV            []string   `json:"srv,omitempty"`
@@ -546,6 +546,15 @@ type DNSData struct {
 	RawResp        *dns.Msg   `json:"raw_resp,omitempty"`
 	Timestamp      time.Time  `json:"timestamp,omitempty"`
 	HostsFile      bool       `json:"hosts_file,omitempty"`
+}
+
+type SOA struct {
+	Name    string `json:"name,omitempty"`
+	Serial  uint32 `json:"serial,omitempty"`
+	Refresh uint32 `json:"refresh,omitempty"`
+	Retry   uint32 `json:"retry,omitempty"`
+	Expire  uint32 `json:"expire,omitempty"`
+	Minttl  uint32 `json:"minttl,omitempty"`
 }
 
 // CheckInternalIPs when set to true returns if DNS response IPs
@@ -569,8 +578,14 @@ func (d *DNSData) ParseFromRR(rrs []dns.RR) error {
 		case *dns.CNAME:
 			d.CNAME = append(d.CNAME, trimChars(recordType.Target))
 		case *dns.SOA:
-			d.SOA = append(d.SOA, trimChars(recordType.Ns))
-			d.SOA = append(d.SOA, trimChars(recordType.Mbox))
+			d.SOA = SOA{
+				Name:    recordType.Hdr.Name,
+				Serial:  recordType.Serial,
+				Refresh: recordType.Refresh,
+				Retry:   recordType.Retry,
+				Expire:  recordType.Expire,
+				Minttl:  recordType.Minttl,
+			}
 		case *dns.PTR:
 			d.PTR = append(d.PTR, trimChars(recordType.Ptr))
 		case *dns.MX:
@@ -614,7 +629,7 @@ func (d *DNSData) ParseFromEnvelopeChan(envChan chan *dns.Envelope) error {
 }
 
 func (d *DNSData) contains() bool {
-	return len(d.A) > 0 || len(d.AAAA) > 0 || len(d.CNAME) > 0 || len(d.MX) > 0 || len(d.NS) > 0 || len(d.PTR) > 0 || len(d.ANY) > 0 || len(d.TXT) > 0 || len(d.SRV) > 0 || len(d.SOA) > 0 || len(d.CAA) > 0
+	return len(d.A) > 0 || len(d.AAAA) > 0 || len(d.CNAME) > 0 || len(d.MX) > 0 || len(d.NS) > 0 || len(d.PTR) > 0 || len(d.ANY) > 0 || len(d.TXT) > 0 || len(d.SRV) > 0 || d.SOA.Name != "" || len(d.CAA) > 0
 }
 
 // JSON returns the object as json string
@@ -635,7 +650,6 @@ func (d *DNSData) dedupe() {
 	d.MX = sliceutil.Dedupe(d.MX)
 	d.PTR = sliceutil.Dedupe(d.PTR)
 	d.ANY = sliceutil.Dedupe(d.ANY)
-	d.SOA = sliceutil.Dedupe(d.SOA)
 	d.NS = sliceutil.Dedupe(d.NS)
 	d.TXT = sliceutil.Dedupe(d.TXT)
 	d.SRV = sliceutil.Dedupe(d.SRV)

--- a/client.go
+++ b/client.go
@@ -530,7 +530,7 @@ type DNSData struct {
 	MX             []string   `json:"mx,omitempty"`
 	PTR            []string   `json:"ptr,omitempty"`
 	ANY            []string   `json:"any,omitempty"`
-	SOA            SOA        `json:"soa,omitempty"`
+	SOA            []SOA      `json:"soa,omitempty"`
 	NS             []string   `json:"ns,omitempty"`
 	TXT            []string   `json:"txt,omitempty"`
 	SRV            []string   `json:"srv,omitempty"`
@@ -578,14 +578,14 @@ func (d *DNSData) ParseFromRR(rrs []dns.RR) error {
 		case *dns.CNAME:
 			d.CNAME = append(d.CNAME, trimChars(recordType.Target))
 		case *dns.SOA:
-			d.SOA = SOA{
+			d.SOA = append(d.SOA, SOA{
 				Name:    recordType.Hdr.Name,
 				Serial:  recordType.Serial,
 				Refresh: recordType.Refresh,
 				Retry:   recordType.Retry,
 				Expire:  recordType.Expire,
 				Minttl:  recordType.Minttl,
-			}
+			})
 		case *dns.PTR:
 			d.PTR = append(d.PTR, trimChars(recordType.Ptr))
 		case *dns.MX:
@@ -629,7 +629,7 @@ func (d *DNSData) ParseFromEnvelopeChan(envChan chan *dns.Envelope) error {
 }
 
 func (d *DNSData) contains() bool {
-	return len(d.A) > 0 || len(d.AAAA) > 0 || len(d.CNAME) > 0 || len(d.MX) > 0 || len(d.NS) > 0 || len(d.PTR) > 0 || len(d.ANY) > 0 || len(d.TXT) > 0 || len(d.SRV) > 0 || d.SOA.Name != "" || len(d.CAA) > 0
+	return len(d.A) > 0 || len(d.AAAA) > 0 || len(d.CNAME) > 0 || len(d.MX) > 0 || len(d.NS) > 0 || len(d.PTR) > 0 || len(d.ANY) > 0 || len(d.TXT) > 0 || len(d.SRV) > 0 || len(d.SOA) > 0 || len(d.CAA) > 0
 }
 
 // JSON returns the object as json string

--- a/client_test.go
+++ b/client_test.go
@@ -66,12 +66,18 @@ func TestDOT(t *testing.T) {
 func TestQueryMultiple(t *testing.T) {
 	client, _ := New([]string{"8.8.8.8:53", "1.1.1.1:53"}, 5)
 
-	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA, dns.TypeAAAA})
+	// Test various query types
+	d, err := client.QueryMultiple("scanme.sh", []uint16{
+		dns.TypeA,
+		dns.TypeAAAA,
+		dns.TypeSOA,
+	})
 	require.Nil(t, err)
 
 	// From current dig result
 	require.True(t, len(d.A) > 0)
 	require.True(t, len(d.AAAA) > 0)
+	require.True(t, len(d.SOA) > 0)
 	require.NotZero(t, d.TTL)
 }
 


### PR DESCRIPTION
Currently retryabledns does not support DNS zone queries, the SOA query gives the nameservers but no zone information.
This modification provides information about the DNS zone.