### PR TITLE
Add udp connection reuse

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
     commit-message:
@@ -17,6 +18,7 @@ updates:
 
   # Maintain dependencies for go modules
   - package-ecosystem: "gomod"
+    target-branch: "main"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -26,6 +28,7 @@ updates:
 
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
+    target-branch: "main"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/client.go
+++ b/client.go
@@ -113,7 +113,7 @@ func NewWithOptions(options Options) (*Client, error) {
 			if err != nil {
 				return nil, err
 			}
-			client.udpConnPool.Set(resolver.String(), udpConnPool)
+			_ = client.udpConnPool.Set(resolver.String(), udpConnPool)
 		}
 	}
 	return &client, nil
@@ -572,7 +572,7 @@ func (c *Client) axfr(host string) (*AXFRData, error) {
 }
 
 func (c *Client) Close() {
-	c.udpConnPool.Iterate(func(_ string, connPool *ConnPool) error {
+	_ = c.udpConnPool.Iterate(func(_ string, connPool *ConnPool) error {
 		connPool.Close()
 		return nil
 	})

--- a/client_queue.go
+++ b/client_queue.go
@@ -1,0 +1,46 @@
+package retryabledns
+
+import (
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type waitingClient struct {
+	returnCh    chan *dns.Conn
+	doneCh      <-chan struct{}
+	arrivalTime time.Time
+	index       int // The index of the item in the heap.
+}
+
+// A clientQueue implements heap.Interface and holds waitingClients.
+type clientQueue []*waitingClient
+
+func (pq clientQueue) Len() int { return len(pq) }
+
+func (pq clientQueue) Less(i, j int) bool {
+	return pq[i].arrivalTime.Before(pq[j].arrivalTime)
+}
+
+func (pq clientQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *clientQueue) Push(x any) {
+	n := len(*pq)
+	item := x.(*waitingClient)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *clientQueue) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}

--- a/connpool.go
+++ b/connpool.go
@@ -1,0 +1,120 @@
+package retryabledns
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type ConnPool struct {
+	items      map[*dns.Conn]bool
+	newArrival chan *waitingClient
+	finished   chan *dns.Conn
+	clients    clientQueue
+	cancel     context.CancelFunc
+	resolver   NetworkResolver
+}
+
+func NewConnPool(resolver NetworkResolver, poolSize int) (*ConnPool, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	pool := &ConnPool{
+		items:      make(map[*dns.Conn]bool, poolSize),
+		newArrival: make(chan *waitingClient),
+		finished:   make(chan *dns.Conn),
+		cancel:     cancel,
+		resolver:   resolver,
+	}
+	heap.Init(&pool.clients)
+	for i := 0; i < poolSize; i++ {
+		conn, err := dns.Dial(resolver.Protocol.String(), resolver.String())
+		if err != nil {
+			return nil, fmt.Errorf("unable to create conn to %s: %w", resolver.String(), err)
+		}
+		pool.items[conn] = false
+	}
+	go pool.coordinate(ctx)
+	return pool, nil
+}
+
+func (cp *ConnPool) LocalAddrs() []*net.UDPAddr {
+	retval := make([]*net.UDPAddr, len(cp.items))
+	i := 0
+	for conn := range cp.items {
+		retval[i] = conn.LocalAddr().(*net.UDPAddr)
+		i++
+	}
+	return retval
+}
+
+func (cp *ConnPool) Resolver() NetworkResolver {
+	return cp.resolver
+}
+
+func (cp *ConnPool) Exchange(ctx context.Context, client *dns.Client, msg *dns.Msg) (r *dns.Msg, rtt time.Duration, err error) {
+	conn, err := cp.getConnection(ctx)
+	if err != nil {
+		return nil, time.Duration(0), err
+	}
+	defer cp.releaseConnection(conn)
+	return client.ExchangeWithConn(msg, conn)
+}
+
+func (cp *ConnPool) Close() {
+	cp.cancel()
+	for conn := range cp.items {
+		conn.Close()
+	}
+}
+
+func (cp *ConnPool) coordinate(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case client := <-cp.newArrival:
+			heap.Push(&cp.clients, client)
+		case conn := <-cp.finished:
+			cp.items[conn] = false
+		}
+		for conn, inUse := range cp.items {
+			if !inUse && len(cp.clients) > 0 {
+				cp.items[conn] = true
+				client := heap.Pop(&cp.clients).(*waitingClient)
+				select {
+				case client.returnCh <- conn:
+				case <-client.doneCh:
+					cp.items[conn] = false
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}
+}
+
+func (cp *ConnPool) getConnection(ctx context.Context) (*dns.Conn, error) {
+	client := &waitingClient{
+		arrivalTime: time.Now(),
+		returnCh:    make(chan *dns.Conn),
+		doneCh:      ctx.Done(),
+	}
+	select {
+	case cp.newArrival <- client:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case conn := <-client.returnCh:
+		return conn, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (cp *ConnPool) releaseConnection(conn *dns.Conn) {
+	cp.finished <- conn
+}

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,16 @@
 module github.com/projectdiscovery/retryabledns
 
-go 1.18
+go 1.20
 
 require (
 	github.com/miekg/dns v1.1.55
 	github.com/stretchr/testify v1.8.4
 )
 
-require github.com/projectdiscovery/blackrock v0.0.1 // indirect
+require (
+	github.com/projectdiscovery/blackrock v0.0.1 // indirect
+	golang.org/x/exp v0.0.0-20221019170559-20944726eadf // indirect
+)
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+golang.org/x/exp v0.0.0-20221019170559-20944726eadf h1:nFVjjKDgNY37+ZSYCJmtYf7tOlfQswHqplG2eosjOMg=
+golang.org/x/exp v0.0.0-20221019170559-20944726eadf/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.12.0 h1:cfawfvKITfUsFCeJIHJrbSxpeu/E81khclypR0GVT50=

--- a/options.go
+++ b/options.go
@@ -13,12 +13,13 @@ var (
 )
 
 type Options struct {
-	BaseResolvers []string
-	MaxRetries    int
-	Timeout       time.Duration
-	Hostsfile     bool
-	LocalAddrIP   net.IP
-	LocalAddrPort uint16
+	BaseResolvers         []string
+	MaxRetries            int
+	Timeout               time.Duration
+	Hostsfile             bool
+	LocalAddrIP           net.IP
+	LocalAddrPort         uint16
+	ConnectionPoolThreads int
 }
 
 // Returns a net.Addr of a UDP or TCP type depending on whats required


### PR DESCRIPTION
Closes #116 

Example code:
```go
rdnsClient, err := retryabledns.NewWithOptions(retryabledns.Options{
		BaseResolvers:         []string{"192.168.5.1:53", "8.8.8.8:53"},
		MaxRetries:            1,
		ConnectionPoolThreads: 10, // To enable connection pool
	})
if err != nil {
	log.Fatal(err)
}
defer rdnsClient.Close()
_, err := rdnsClient.QueryMultiple("example.com", []uint16{dns.TypeA})
if err != nil {
	log.Fatal(err)
}
```