### PR TITLE
introduce MaxLines for `/etc/hosts` file processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ $ go get github.com/projectdiscovery/retryabledns
 
 After this command *retryabledns* library source will be in your $GOPATH
 
+## `/etc/hosts` file processing
+By default, the library processes the `/etc/hosts` file up to a maximum of 500 lines for efficiency. If your setup has a larger hosts file and you want to process more lines, you can easily configure this limit by adjusting the `hostsfile.MaxLines` variable.
+
+For example:
+``` go
+hostsfile.MaxLines = 1000  // Now the library will process up to 1000 lines from the hosts file
+```
+
 ## Example
 Usage Example:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Retryable dns resolver
+
 Based on `miekg/dns` and freely inspired by `bogdanovich/dns_resolver`.
 
 ## Features
+
 - Supports system default resolvers along with user supplied ones
 - Retries dns requests in case of I/O, Time, Network failures
 - Allows arbitrary query types
@@ -9,21 +11,24 @@ Based on `miekg/dns` and freely inspired by `bogdanovich/dns_resolver`.
 
 ### Using *go get*
 
-```
+```console
 $ go get github.com/projectdiscovery/retryabledns
 ```
 
 After this command *retryabledns* library source will be in your $GOPATH
 
 ## `/etc/hosts` file processing
-By default, the library processes the `/etc/hosts` file up to a maximum of 500 lines for efficiency. If your setup has a larger hosts file and you want to process more lines, you can easily configure this limit by adjusting the `hostsfile.MaxLines` variable.
+
+By default, the library processes the `/etc/hosts` file up to a maximum amount of lines for efficiency (4096). If your setup has a larger hosts file and you want to process more lines, you can easily configure this limit by adjusting the `hostsfile.MaxLines` variable.
 
 For example:
+
 ``` go
-hostsfile.MaxLines = 1000  // Now the library will process up to 1000 lines from the hosts file
+hostsfile.MaxLines = 10000  // Now the library will process up to 10000 lines from the hosts file
 ```
 
 ## Example
+
 Usage Example:
 
 ``` go
@@ -62,5 +67,6 @@ func main() {
 ```
 
 Credits:
-- https://github.com/lixiangzhong/dnsutil
-- https://github.com/rs/dnstrace
+
+- `https://github.com/lixiangzhong/dnsutil`
+- `https://github.com/rs/dnstrace`

--- a/hostsfile/hostsfile.go
+++ b/hostsfile/hostsfile.go
@@ -12,13 +12,12 @@ import (
 )
 
 const (
-	localhostName   = "localhost"
-	defaultMaxLines = 500
+	localhostName = "localhost"
 )
 
 var (
 	// MaxLines defines the maximum number of lines the Parse function will process from the hosts file.
-	MaxLines = defaultMaxLines
+	MaxLines = 4096
 )
 
 func Path() string {

--- a/hostsfile/hostsfile.go
+++ b/hostsfile/hostsfile.go
@@ -12,7 +12,13 @@ import (
 )
 
 const (
-	localhostName = "localhost"
+	localhostName   = "localhost"
+	defaultMaxLines = 500
+)
+
+var (
+	// MaxLines defines the maximum number of lines the Parse function will process from the hosts file.
+	MaxLines = defaultMaxLines
 )
 
 func Path() string {
@@ -37,7 +43,14 @@ func Parse(p string) (map[string][]string, error) {
 	}
 
 	items := make(map[string][]string)
+	lineCount := 0
+
 	for line := range hostsFileCh {
+		lineCount++
+		if lineCount > MaxLines {
+			break
+		}
+
 		line = strings.TrimSpace(line)
 		// skip comments and empty lines
 		if line == "" || strings.HasPrefix(line, "#") {


### PR DESCRIPTION
### Proposal:
The content of hosts file (`/etc/hosts`) is processed fully, leading to high memory consumptions if many records are defined. By default the processing should stop after a reasonable high amount of lines. The option should be documented and defined as package variable so that it can be overridden.

Closes #167.