### PR TITLE
fix: no records behavior

### DIFF
--- a/client.go
+++ b/client.go
@@ -498,7 +498,7 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 		}
 		// Finished retry loop at limit, bail out
 		if i == c.options.MaxRetries && err != nil {
-			err = ErrRetriesExceeded
+			err = errors.Join(ErrRetriesExceeded, err)
 			break
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -497,7 +497,7 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 			}
 		}
 		// Finished retry loop at limit, bail out
-		if i == c.options.MaxRetries {
+		if i == c.options.MaxRetries && err != nil {
 			err = ErrRetriesExceeded
 			break
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -129,7 +129,7 @@ func TestRetries(t *testing.T) {
 
 	// Test that error is returned on max retries, should conn refused 5 times then err
 	_, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
-	require.True(t, err == ErrRetriesExceeded)
+	require.ErrorIs(t, err, ErrRetriesExceeded)
 
 	msg := &dns.Msg{}
 	msg.Id = dns.Id()

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,6 +146,22 @@ func TestRetries(t *testing.T) {
 	// Test with raw Do() interface as well
 	_, err = client.Do(msg)
 	require.True(t, err == ErrRetriesExceeded)
+}
+
+func TestNoRecords(t *testing.T) {
+	client, err := New([]string{"8.8.8.8:53", "1.1.1.1:53"}, 5)
+	require.NoError(t, err)
+
+	// Test various query types
+	res, err := client.QueryMultiple("donotexist.scanme.sh", []uint16{
+		dns.TypeA,
+		dns.TypeAAAA,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.Empty(t, res.A)
+	assert.Empty(t, res.AAAA)
 }
 
 func TestTrace(t *testing.T) {


### PR DESCRIPTION
PR https://github.com/projectdiscovery/retryabledns/pull/222 included in release https://github.com/projectdiscovery/retryabledns/releases/tag/v1.0.75 introduced a breaking change:
When no record are found, the error `ErrRetriesExceeded` is returned instead of an empty response.

This PR restore the previous behavior.