### PR TITLE
if udp fails, fallback to tcp connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,13 +111,14 @@ func NewWithOptions(options Options) (*Client, error) {
 	}
 
 	client := Client{
-		options:    options,
-		resolvers:  parsedBaseResolvers,
-		udpClient:  udpClient,
-		tcpClient:  tcpClient,
-		dohClient:  dohClient,
-		dotClient:  dotClient,
-		knownHosts: knownHosts,
+		options:     options,
+		resolvers:   parsedBaseResolvers,
+		udpClient:   udpClient,
+		tcpClient:   tcpClient,
+		dohClient:   dohClient,
+		dotClient:   dotClient,
+		knownHosts:  knownHosts,
+		TCPFallback: options.TCPFallback,
 	}
 
 	if options.Proxy != "" {
@@ -223,6 +224,11 @@ func (c *Client) Do(msg *dns.Msg) (*dns.Msg, error) {
 				} else if c.udpProxy != nil {
 					var udpConn *dns.Conn
 					udpConn, err = c.dialWithProxy(c.udpProxy, "udp", resolver.String())
+
+					if err != nil {
+						udpConn, err = c.dialWithProxy(c.udpProxy, "tcp", resolver.String())
+					}
+
 					if err != nil {
 						break
 					}

--- a/client_test.go
+++ b/client_test.go
@@ -55,7 +55,7 @@ func TestConsistentResolve(t *testing.T) {
 
 	var last string
 	for i := 0; i < 10; i++ {
-		d, err := client.Resolve("example.com")
+		d, err := client.Resolve("scanme.sh")
 		require.Nil(t, err, "could not resolve dns")
 
 		if last != "" {
@@ -69,7 +69,7 @@ func TestConsistentResolve(t *testing.T) {
 func TestUDP(t *testing.T) {
 	client, _ := New([]string{"1.1.1.1:53", "udp:8.8.8.8"}, 5)
 
-	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
+	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
 	require.Nil(t, err)
 
 	// From current dig result
@@ -79,7 +79,7 @@ func TestUDP(t *testing.T) {
 func TestTCP(t *testing.T) {
 	client, _ := New([]string{"tcp:1.1.1.1:53", "tcp:8.8.8.8"}, 5)
 
-	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
+	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
 	require.Nil(t, err)
 
 	// From current dig result
@@ -89,7 +89,7 @@ func TestTCP(t *testing.T) {
 func TestDOH(t *testing.T) {
 	client, _ := New([]string{"doh:https://doh.opendns.com/dns-query:post", "doh:https://doh.opendns.com/dns-query:get"}, 5)
 
-	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
+	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
 	require.Nil(t, err)
 
 	// From current dig result
@@ -99,7 +99,7 @@ func TestDOH(t *testing.T) {
 func TestDOT(t *testing.T) {
 	client, _ := New([]string{"dot:dns.google:853", "dot:1dot1dot1dot1.cloudflare-dns.com"}, 5)
 
-	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
+	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
 	require.Nil(t, err)
 
 	// From current dig result

--- a/doh/doh_client_test.go
+++ b/doh/doh_client_test.go
@@ -11,7 +11,7 @@ func TestConsistentResolve(t *testing.T) {
 	client := New()
 	var lastAnswer string
 	for i := 0; i < 10; i++ {
-		d, err := client.Query("example.com", A)
+		d, err := client.Query("scanme.sh", A)
 		require.Nil(t, err, "could not resolve dns")
 		if lastAnswer == "" {
 			lastAnswer = d.Answer[0].Data

--- a/options.go
+++ b/options.go
@@ -21,7 +21,6 @@ var (
 		BaseResolvers: BaseResolvers,
 		MaxRetries:    1,
 		Timeout:       3 * time.Second,
-		TCPFallback:   true,
 	}
 )
 
@@ -35,7 +34,6 @@ type Options struct {
 	ConnectionPoolThreads int
 	MaxPerCNAMEFollows    int
 	Proxy                 string
-	TCPFallback           bool
 }
 
 // Returns a net.Addr of a UDP or TCP type depending on whats required

--- a/options.go
+++ b/options.go
@@ -10,6 +10,19 @@ import (
 var (
 	ErrMaxRetriesZero = errors.New("retries must be at least 1")
 	ErrResolversEmpty = errors.New("resolvers list must not be empty")
+
+	BaseResolvers = []string{
+		"1.1.1.1:53",
+		"1.0.0.1:53",
+		"8.8.8.8:53",
+		"8.8.4.4:53",
+	}
+	DefaultOptions = Options{
+		BaseResolvers: BaseResolvers,
+		MaxRetries:    1,
+		Timeout:       3 * time.Second,
+		TCPFallback:   true,
+	}
 )
 
 type Options struct {
@@ -22,6 +35,7 @@ type Options struct {
 	ConnectionPoolThreads int
 	MaxPerCNAMEFollows    int
 	Proxy                 string
+	TCPFallback           bool
 }
 
 // Returns a net.Addr of a UDP or TCP type depending on whats required


### PR DESCRIPTION
- incase of proxy, dail function fails with `network not implemented` error
- ref: 
  - https://github.com/golang/go/issues/38015
  - https://github.com/golang/go/issues/32790
- reproduced example
```package main

import (
	"fmt"
	"net"
	"time"

	"github.com/miekg/dns"
	"golang.org/x/net/proxy"
)

func main() {
	// Create SOCKS5 proxy dialer
	proxyAddr := "localhost:37367"
	auth := &proxy.Auth{
		User:     "abc",
		Password: "abc",
	}
	fmt.Printf("Attempting to connect to SOCKS5 proxy at %s\n", proxyAddr)

	dialer, err := proxy.SOCKS5("tcp", proxyAddr, auth, nil)
	if err != nil {
		fmt.Printf("Failed to create SOCKS5 dialer: %v\n", err)
		return
	}

	// Try TCP first (this should work)
	fmt.Println("\nTesting TCP connection:")
	testConnection(dialer, "tcp", "8.8.8.8:53")

	// Try UDP (this will fail with "network not implemented")
	fmt.Println("\nTesting UDP connection:")
	testConnection(dialer, "udp", "8.8.8.8:53")

	// Demonstrate a working DNS query over TCP
	fmt.Println("\nAttempting DNS query over TCP:")
	performDNSQuery(dialer)
}

func testConnection(dialer proxy.Dialer, network, address string) {
	fmt.Printf("Attempting to dial %s via %s\n", address, network)

	conn, err := dialer.Dial(network, address)
	if err != nil {
		fmt.Printf("Dial error: %v\n", err)
		return
	}
	defer conn.Close()

	fmt.Printf("Successfully connected to %s via %s\n", address, network)
}


var question = "google.com."

func performDNSQuery(dialer proxy.Dialer) {
	// Create a DNS client
	client := &dns.Client{
		Net: "tcp", // Force TCP
		Dialer: &net.Dialer{
			Timeout: 5 * time.Second,
		},
	}

	// Create a DNS message
	m := new(dns.Msg)
	m.SetQuestion(question, dns.TypeA)
	m.RecursionDesired = true

	// Try to connect to Google's DNS server through the proxy
	dnsServer := "8.8.8.8:53"
	fmt.Printf("Attempting DNS query for google.com to %s\n", dnsServer)

	// Create a connection through the proxy
	conn, err := dialer.Dial("tcp", dnsServer)
	if err != nil {
		fmt.Printf("Failed to connect to DNS server: %v\n", err)
		return
	}
	defer conn.Close()

	// Create DNS connection
	dnsConn := &dns.Conn{Conn: conn}
	defer dnsConn.Close()

	// Send the query
	fmt.Println("Sending DNS query...")
	response, _, err := client.ExchangeWithConn(m, dnsConn)
	if err != nil {
		fmt.Printf("DNS query failed: %v\n", err)
		return
	}

	// Print results
	fmt.Println("\nDNS Response:")
	for _, answer := range response.Answer {
		fmt.Printf("Answer: %v\n", answer)
	}
}
```