### PR TITLE
Fix: Internal IP detection not working when using hosts file entries

### DIFF
--- a/client.go
+++ b/client.go
@@ -366,8 +366,20 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 			for _, ip := range ips {
 				if iputil.IsIPv4(ip) {
 					dnsdata.A = append(dnsdata.A, ip)
+					if CheckInternalIPs && internalRangeCheckerInstance != nil {
+						if parsedIP := net.ParseIP(ip); parsedIP != nil && internalRangeCheckerInstance.ContainsIPv4(parsedIP) {
+							dnsdata.HasInternalIPs = true
+							dnsdata.InternalIPs = append(dnsdata.InternalIPs, ip)
+						}
+					}
 				} else if iputil.IsIPv6(ip) {
 					dnsdata.AAAA = append(dnsdata.AAAA, ip)
+					if CheckInternalIPs && internalRangeCheckerInstance != nil {
+						if parsedIP := net.ParseIP(ip); parsedIP != nil && internalRangeCheckerInstance.ContainsIPv6(parsedIP) {
+							dnsdata.HasInternalIPs = true
+							dnsdata.InternalIPs = append(dnsdata.InternalIPs, ip)
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
closes: https://github.com/projectdiscovery/retryabledns/issues/263
relates: https://github.com/projectdiscovery/aurora/issues/2493
## Problem
The internal IP detection feature (`CheckInternalIPs`) was not working when DNS resolution came from hosts file entries. The `HasInternalIPs` and `InternalIPs` fields were not populated even when the resolved IPs were internal addresses.

## Root Cause
In the `queryMultiple` function, when `c.options.Hostsfile` is true and hosts are found in `c.knownHosts`, the code directly populated the `dnsdata.A` and `dnsdata.AAAA` arrays without calling the internal IP detection logic that exists in the `ParseFromRR` method.

**Problematic code (lines 367-375):**
```go
if iputil.IsIPv4(ip) {
    dnsdata.A = append(dnsdata.A, ip)  // Missing internal IP check
} else if iputil.IsIPv6(ip) {
    dnsdata.AAAA = append(dnsdata.AAAA, ip)  // Missing internal IP check
}
```

## Solution
Added internal IP detection logic directly to the hosts file processing section in `queryMultiple` function:

```go
if iputil.IsIPv4(ip) {
    dnsdata.A = append(dnsdata.A, ip)
    if CheckInternalIPs && internalRangeCheckerInstance != nil {
        if parsedIP := net.ParseIP(ip); parsedIP != nil && internalRangeCheckerInstance.ContainsIPv4(parsedIP) {
            dnsdata.HasInternalIPs = true
            dnsdata.InternalIPs = append(dnsdata.InternalIPs, ip)
        }
    }
} else if iputil.IsIPv6(ip) {
    dnsdata.AAAA = append(dnsdata.AAAA, ip)
    if CheckInternalIPs && internalRangeCheckerInstance != nil {
        if parsedIP := net.ParseIP(ip); parsedIP != nil && internalRangeCheckerInstance.ContainsIPv6(parsedIP) {
            dnsdata.HasInternalIPs = true
            dnsdata.InternalIPs = append(dnsdata.InternalIPs, ip)
        }
    }
}
```

## Changes Made
- **Modified**: `client.go` - Added internal IP detection logic to hosts file processing
- **Added**: Comprehensive tests in `client_test.go` to verify the fix works correctly

## Testing
Added two new test functions:
1. `TestInternalIPDetectionWithHostsFile` - Tests various scenarios with internal/external IPs
2. `TestInternalIPDetectionJSONOutput` - Verifies JSON output contains correct fields

**Test Results:**
- ✅ `HasInternalIPs` correctly set to `true` for internal IPs from hosts file
- ✅ `InternalIPs` array properly populated with internal IP addresses  
- ✅ External IPs correctly identified as non-internal
- ✅ JSON output includes expected fields: `"has_internal_ips":true`, `"internal_ips":["127.0.0.1"]`

## Backward Compatibility
This fix maintains full backward compatibility and only affects the behavior when `CheckInternalIPs = true` and hosts file entries contain internal IP addresses.
