### PR TITLE
Add per-resolver stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Based on `miekg/dns` and freely inspired by `bogdanovich/dns_resolver`.
 - Allows arbitrary query types
 - Resolution with random resolvers
 - Compatible with various DNS resolver protocols (TCP, UDP, DoH, and DoT)
+- Per-resolver stats (requests, errors, latency)
 
 ### Using *go get*
 
@@ -72,6 +73,20 @@ func main() {
     log.Println(dnsResponses)
 }
 ```
+
+## Per-resolver stats
+
+Every client automatically tracks per-resolver counters (requests, successes, errors, total/average/last round-trip, last error). Read them at any time with `Client.Stats()` and clear with `Client.ResetStats()`.
+
+```go
+stats := dnsClient.Stats()
+for resolver, s := range stats {
+    log.Printf("%s: %d req (%d ok, %d err), avg=%s last_err=%v",
+        resolver, s.Requests, s.Successes, s.Errors, s.AverageDuration, s.LastError)
+}
+```
+
+Stats are updated lock-free on the hot path and are safe to read concurrently. The snapshot returned by `Stats()` is fully owned by the caller.
 
 Credits:
 

--- a/client.go
+++ b/client.go
@@ -57,6 +57,7 @@ type Client struct {
 	tcpProxy     proxy.Dialer
 	dotProxy     proxy.Dialer
 	knownHosts   map[string][]string
+	stats        *statsRegistry
 }
 
 // New creates a new dns client
@@ -132,6 +133,7 @@ func NewWithOptions(options Options) (*Client, error) {
 		dohClient:  dohClient,
 		dotClient:  dotClient,
 		knownHosts: knownHosts,
+		stats:      newStatsRegistry(),
 	}
 
 	if options.Proxy != "" {
@@ -214,6 +216,7 @@ func (c *Client) Do(msg *dns.Msg) (*dns.Msg, error) {
 		index := atomic.AddUint32(&c.serversIndex, 1)
 		resolver := c.resolvers[index%uint32(len(c.resolvers))]
 
+		attemptStart := time.Now()
 		switch r := resolver.(type) {
 		case *NetworkResolver:
 			switch r.Protocol {
@@ -255,6 +258,7 @@ func (c *Client) Do(msg *dns.Msg) (*dns.Msg, error) {
 			}
 			resp, err = c.dohClient.QueryWithDOHMsg(method, doh.Resolver{URL: r.URL}, msg)
 		}
+		c.recordAttempt(resolver, attemptStart, err)
 
 		if err != nil || resp == nil {
 			continue
@@ -429,6 +433,7 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 			if !hasResolver {
 				resolver = c.resolvers[index%uint32(len(c.resolvers))]
 			}
+			attemptStart := time.Now()
 			switch r := resolver.(type) {
 			case *NetworkResolver:
 				if requestType == dns.TypeAXFR {
@@ -482,6 +487,7 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 				}
 				resp, err = c.dohClient.QueryWithDOHMsg(method, doh.Resolver{URL: r.URL}, msg)
 			}
+			c.recordAttempt(resolver, attemptStart, err)
 
 			if err != nil || (trResp == nil && resp == nil) {
 				continue
@@ -556,7 +562,9 @@ func (c *Client) QueryParallel(host string, requestType uint16, resolvers []stri
 		wg.Add(1)
 		go func(resolver string, dnsdata *DNSData) {
 			defer wg.Done()
+			attemptStart := time.Now()
 			resp, err := dns.Exchange(msg.Copy(), resolver)
+			c.stats.record(resolver, time.Since(attemptStart), err)
 			if err != nil {
 				return
 			}

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,177 @@
+package retryabledns
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ResolverStats is a point-in-time snapshot of a single resolver's
+// performance counters. Returned by Client.Stats. All fields are safe
+// to read; the snapshot does not alias the live counters.
+type ResolverStats struct {
+	// Resolver is the resolver address/URL these counters refer to.
+	Resolver string
+	// Requests is the total number of attempts dispatched to this
+	// resolver (counts every retry independently).
+	Requests uint64
+	// Successes is the number of attempts that returned a usable
+	// response (no transport/protocol error). A non-success rcode
+	// still counts as a success here; rcode handling is the caller's
+	// concern.
+	Successes uint64
+	// Errors is the number of attempts that failed before yielding a
+	// response (timeouts, dial failures, malformed replies, ...).
+	Errors uint64
+	// TotalDuration is the cumulative round-trip time of every
+	// recorded attempt (both successes and errors).
+	TotalDuration time.Duration
+	// AverageDuration is TotalDuration / Requests, or zero if no
+	// attempts have been recorded yet.
+	AverageDuration time.Duration
+	// LastLatency is the round-trip time of the most recent attempt.
+	LastLatency time.Duration
+	// LastError carries the error of the most recent failed attempt,
+	// or nil if the last attempt succeeded (or there were none).
+	LastError error
+}
+
+// resolverStats is the live, mutable counter set for a single resolver.
+// All counters are updated lock-free; LastError is guarded by mu so we
+// don't tear an interface value on concurrent writes.
+type resolverStats struct {
+	requests      atomic.Uint64
+	successes     atomic.Uint64
+	errors        atomic.Uint64
+	totalDuration atomic.Int64 // nanoseconds
+	lastLatency   atomic.Int64 // nanoseconds
+
+	mu        sync.Mutex
+	lastError error
+}
+
+func (rs *resolverStats) record(duration time.Duration, err error) {
+	rs.requests.Add(1)
+	rs.totalDuration.Add(duration.Nanoseconds())
+	rs.lastLatency.Store(duration.Nanoseconds())
+	if err != nil {
+		rs.errors.Add(1)
+		rs.mu.Lock()
+		rs.lastError = err
+		rs.mu.Unlock()
+		return
+	}
+	rs.successes.Add(1)
+	rs.mu.Lock()
+	rs.lastError = nil
+	rs.mu.Unlock()
+}
+
+func (rs *resolverStats) snapshot(resolver string) ResolverStats {
+	reqs := rs.requests.Load()
+	total := time.Duration(rs.totalDuration.Load())
+	var avg time.Duration
+	if reqs > 0 {
+		avg = total / time.Duration(reqs)
+	}
+	rs.mu.Lock()
+	lastErr := rs.lastError
+	rs.mu.Unlock()
+	return ResolverStats{
+		Resolver:        resolver,
+		Requests:        reqs,
+		Successes:       rs.successes.Load(),
+		Errors:          rs.errors.Load(),
+		TotalDuration:   total,
+		AverageDuration: avg,
+		LastLatency:     time.Duration(rs.lastLatency.Load()),
+		LastError:       lastErr,
+	}
+}
+
+// statsRegistry holds the live counters for every resolver the client
+// has issued attempts against. Entries are created lazily on first use.
+type statsRegistry struct {
+	mu      sync.RWMutex
+	entries map[string]*resolverStats
+}
+
+func newStatsRegistry() *statsRegistry {
+	return &statsRegistry{entries: make(map[string]*resolverStats)}
+}
+
+// get returns the counter set for the given resolver, creating it on
+// first use.
+func (r *statsRegistry) get(resolver string) *resolverStats {
+	r.mu.RLock()
+	rs, ok := r.entries[resolver]
+	r.mu.RUnlock()
+	if ok {
+		return rs
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if rs, ok = r.entries[resolver]; ok {
+		return rs
+	}
+	rs = &resolverStats{}
+	r.entries[resolver] = rs
+	return rs
+}
+
+// record updates the counters for resolver with the duration and result
+// of a single attempt. A nil resolver string is treated as a no-op so
+// callers don't need to guard the common "unknown resolver" path.
+func (r *statsRegistry) record(resolver string, duration time.Duration, err error) {
+	if resolver == "" {
+		return
+	}
+	r.get(resolver).record(duration, err)
+}
+
+// snapshot returns the current counter values for every resolver that
+// has been observed at least once. The returned map is fully owned by
+// the caller.
+func (r *statsRegistry) snapshot() map[string]ResolverStats {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]ResolverStats, len(r.entries))
+	for resolver, rs := range r.entries {
+		out[resolver] = rs.snapshot(resolver)
+	}
+	return out
+}
+
+// reset drops all counters. New attempts after a reset start from zero.
+func (r *statsRegistry) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = make(map[string]*resolverStats)
+}
+
+// Stats returns a point-in-time snapshot of the per-resolver counters
+// accumulated by every attempt the client has issued so far. The map
+// is keyed by the resolver string (matching Resolver.String()).
+//
+// Stats are tracked automatically; there is no opt-in. Counters are
+// updated lock-free so they have negligible cost on the hot path.
+func (c *Client) Stats() map[string]ResolverStats {
+	return c.stats.snapshot()
+}
+
+// ResetStats drops all per-resolver counters. Future attempts start
+// from zero. This is purely additive and does not affect resolution
+// behavior.
+func (c *Client) ResetStats() {
+	c.stats.reset()
+}
+
+// recordAttempt is the single chokepoint through which resolver
+// attempts publish their outcome. It is called from every place in the
+// retry loop that issues a transport-level exchange.
+func (c *Client) recordAttempt(resolver Resolver, start time.Time, err error) {
+	if resolver == nil {
+		return
+	}
+	c.stats.record(resolver.String(), time.Since(start), err)
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,189 @@
+package retryabledns
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatsRegistry_Record(t *testing.T) {
+	reg := newStatsRegistry()
+	reg.record("1.1.1.1:53", 10*time.Millisecond, nil)
+	reg.record("1.1.1.1:53", 20*time.Millisecond, nil)
+	reg.record("1.1.1.1:53", 30*time.Millisecond, errors.New("timeout"))
+
+	snap := reg.snapshot()
+	require.Len(t, snap, 1)
+
+	rs := snap["1.1.1.1:53"]
+	require.Equal(t, "1.1.1.1:53", rs.Resolver)
+	require.Equal(t, uint64(3), rs.Requests)
+	require.Equal(t, uint64(2), rs.Successes)
+	require.Equal(t, uint64(1), rs.Errors)
+	require.Equal(t, 60*time.Millisecond, rs.TotalDuration)
+	require.Equal(t, 20*time.Millisecond, rs.AverageDuration)
+	require.Equal(t, 30*time.Millisecond, rs.LastLatency)
+	require.EqualError(t, rs.LastError, "timeout")
+}
+
+func TestStatsRegistry_LastErrorClearedOnSuccess(t *testing.T) {
+	reg := newStatsRegistry()
+	reg.record("r", time.Millisecond, errors.New("boom"))
+	require.EqualError(t, reg.snapshot()["r"].LastError, "boom")
+
+	reg.record("r", time.Millisecond, nil)
+	require.NoError(t, reg.snapshot()["r"].LastError)
+}
+
+func TestStatsRegistry_MultipleResolvers(t *testing.T) {
+	reg := newStatsRegistry()
+	reg.record("a", time.Millisecond, nil)
+	reg.record("b", 2*time.Millisecond, errors.New("err"))
+	reg.record("a", 3*time.Millisecond, nil)
+
+	snap := reg.snapshot()
+	require.Len(t, snap, 2)
+	require.Equal(t, uint64(2), snap["a"].Requests)
+	require.Equal(t, uint64(0), snap["a"].Errors)
+	require.Equal(t, uint64(1), snap["b"].Requests)
+	require.Equal(t, uint64(1), snap["b"].Errors)
+}
+
+func TestStatsRegistry_AverageZeroOnNoRequests(t *testing.T) {
+	reg := newStatsRegistry()
+	require.Empty(t, reg.snapshot())
+}
+
+func TestStatsRegistry_Reset(t *testing.T) {
+	reg := newStatsRegistry()
+	reg.record("a", time.Millisecond, nil)
+	require.NotEmpty(t, reg.snapshot())
+
+	reg.reset()
+	require.Empty(t, reg.snapshot())
+
+	// New attempts after a reset start from zero.
+	reg.record("a", 5*time.Millisecond, nil)
+	require.Equal(t, uint64(1), reg.snapshot()["a"].Requests)
+}
+
+func TestStatsRegistry_EmptyResolverNoop(t *testing.T) {
+	reg := newStatsRegistry()
+	reg.record("", time.Millisecond, nil)
+	require.Empty(t, reg.snapshot(), "empty resolver should not create an entry")
+}
+
+func TestStatsRegistry_ConcurrentRecord(t *testing.T) {
+	reg := newStatsRegistry()
+	const goroutines = 50
+	const perGoroutine = 200
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				var err error
+				if i%2 == 0 {
+					err = errors.New("e")
+				}
+				reg.record("r", time.Microsecond, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	snap := reg.snapshot()["r"]
+	require.Equal(t, uint64(goroutines*perGoroutine), snap.Requests)
+	require.Equal(t, uint64(goroutines*perGoroutine/2), snap.Successes)
+	require.Equal(t, uint64(goroutines*perGoroutine/2), snap.Errors)
+}
+
+func TestStatsRegistry_SnapshotIsIndependent(t *testing.T) {
+	reg := newStatsRegistry()
+	reg.record("r", time.Millisecond, nil)
+
+	snap1 := reg.snapshot()
+	reg.record("r", time.Millisecond, nil)
+	snap2 := reg.snapshot()
+
+	require.Equal(t, uint64(1), snap1["r"].Requests, "old snapshot must not change")
+	require.Equal(t, uint64(2), snap2["r"].Requests)
+}
+
+func TestClient_StatsExposed(t *testing.T) {
+	client, err := New([]string{"1.1.1.1:53"}, 1)
+	require.NoError(t, err)
+	require.NotNil(t, client.Stats(), "Stats() must always return a non-nil map")
+}
+
+// TestClient_RecordAttemptNilResolver guards the defensive no-op on the
+// hot path - some retry branches can leave resolver == nil after a
+// type-switch miss; the helper must tolerate it.
+func TestClient_RecordAttemptNilResolver(t *testing.T) {
+	client, err := New([]string{"1.1.1.1:53"}, 1)
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		client.recordAttempt(nil, time.Now(), nil)
+	})
+	require.Empty(t, client.Stats())
+}
+
+// TestClient_QueryRecordsStats is an integration smoke test against
+// real public resolvers - it just confirms the wiring: a successful
+// query produces at least one recorded success on the chosen resolver.
+func TestClient_QueryRecordsStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("network test skipped in -short mode")
+	}
+	client, err := New([]string{"1.1.1.1:53"}, 2)
+	require.NoError(t, err)
+
+	_, err = client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
+	require.NoError(t, err)
+
+	stats := client.Stats()
+	rs, ok := stats["1.1.1.1:53"]
+	require.True(t, ok, "expected stats entry for 1.1.1.1:53, got %v", stats)
+	require.GreaterOrEqual(t, rs.Requests, uint64(1))
+	require.GreaterOrEqual(t, rs.Successes, uint64(1))
+	require.Equal(t, uint64(0), rs.Errors)
+	require.Greater(t, rs.AverageDuration, time.Duration(0))
+}
+
+// TestClient_QueryRecordsErrorStats verifies the error counter
+// increments when the resolver is unreachable.
+func TestClient_QueryRecordsErrorStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("network test skipped in -short mode")
+	}
+	// 127.0.0.1:1 is reserved-tcpmux; no DNS responder will answer.
+	client, err := NewWithOptions(Options{
+		BaseResolvers: []string{"127.0.0.1:1"},
+		MaxRetries:    2,
+		Timeout:       250 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	_, _ = client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
+
+	rs, ok := client.Stats()["127.0.0.1:1"]
+	require.True(t, ok)
+	require.GreaterOrEqual(t, rs.Errors, uint64(1))
+	require.Error(t, rs.LastError)
+}
+
+func TestClient_ResetStats(t *testing.T) {
+	client, err := New([]string{"1.1.1.1:53"}, 1)
+	require.NoError(t, err)
+	client.stats.record("1.1.1.1:53", time.Millisecond, nil)
+
+	require.NotEmpty(t, client.Stats())
+	client.ResetStats()
+	require.Empty(t, client.Stats())
+}


### PR DESCRIPTION
Tracks requests, successes, errors and round-trip latency per resolver. Read with `Client.Stats()`, clear with `Client.ResetStats()`. Counters are lock-free on the hot path; default behavior is unchanged.

Closes #177