### PR TITLE
add ExitOnStatusCodes to stop retrying on configured rcodes

### DIFF
--- a/client.go
+++ b/client.go
@@ -260,12 +260,17 @@ func (c *Client) Do(msg *dns.Msg) (*dns.Msg, error) {
 			continue
 		}
 
-		if resp.Rcode != dns.RcodeSuccess {
+		if !c.options.exitOnRcode(resp.Rcode) {
 			continue
 		}
 
 		// In case we get a non empty answer stop retrying
 		return resp, nil
+	}
+	// When ExitOnStatusCodes is set, suppress non-definitive trailing
+	// responses so callers can't mistake them for an answer.
+	if len(c.options.ExitOnStatusCodes) > 0 && resp != nil && !c.options.exitOnRcode(resp.Rcode) {
+		resp = nil
 	}
 	return resp, ErrRetriesExceeded
 }
@@ -495,6 +500,15 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 				}
 			}
 
+			// https://github.com/projectdiscovery/retryabledns/issues/250
+			// When ExitOnStatusCodes is set, drop attempts whose rcode
+			// is not in the list before they touch dnsdata. This keeps
+			// dnsdata.Raw / dnsdata.Resolver / status fields free of
+			// data from intermediate non-definitive responses.
+			if resp != nil && len(c.options.ExitOnStatusCodes) > 0 && !c.options.exitOnRcode(resp.Rcode) {
+				continue
+			}
+
 			switch requestType {
 			case dns.TypeAXFR:
 				err = dnsdata.ParseFromEnvelopeChan(trResp)
@@ -520,12 +534,20 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 			dnsdata.Resolver = append(dnsdata.Resolver, resolver.String())
 
 			if err != nil || !dnsdata.contains() {
+				// An empty response can still be a definitive answer
+				// (e.g. NXDOMAIN) when the user has opted into that via
+				// ExitOnStatusCodes. Break so callers see the status
+				// code without further retries polluting dnsdata.
+				if len(c.options.ExitOnStatusCodes) > 0 && resp != nil && c.options.exitOnRcode(resp.Rcode) {
+					break
+				}
 				continue
 			}
 			dnsdata.dedupe()
 
-			// stop on success
-			if resp != nil && resp.Rcode == dns.RcodeSuccess {
+			// stop on a definitive rcode (success by default, or any of
+			// the user-provided ExitOnStatusCodes)
+			if resp != nil && c.options.exitOnRcode(resp.Rcode) {
 				break
 			}
 			if trResp != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -2,191 +2,217 @@ package retryabledns
 
 import (
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+const fakeHost = "scanme.test"
+
 func TestDialerLocalAddr(t *testing.T) {
+	fr := newFakeResolver(t, dns.RcodeSuccess, arecord(fakeHost, "203.0.113.10"))
+
 	/** Works without LocalAddrIP **/
 	options := Options{
-		BaseResolvers: []string{"1.1.1.1:53", "udp:8.8.8.8"},
+		BaseResolvers: []string{fr.Addr()},
 		MaxRetries:    3,
+		Timeout:       500 * time.Millisecond,
 	}
-	err := options.Validate()
-	require.Nil(t, err)
-	client, _ := NewWithOptions(options)
-	d, err := client.QueryMultiple("example.com", []uint16{dns.TypeA})
-	require.Nil(t, err)
-	// From current dig result
-	require.True(t, len(d.A) > 0)
+	require.NoError(t, options.Validate())
+	client, err := NewWithOptions(options)
+	require.NoError(t, err)
+	d, err := client.QueryMultiple(fakeHost, []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.Equal(t, []string{"203.0.113.10"}, d.A)
 
 	/** Errors with invalid LocalAddrIP **/
+	// 1.2.3.4 is not assigned to any local interface, so the dialer
+	// must fail to bind regardless of where the resolver lives.
 	options = Options{
-		BaseResolvers: []string{"1.1.1.1:53", "udp:8.8.8.8"},
+		BaseResolvers: []string{fr.Addr()},
 		MaxRetries:    3,
+		Timeout:       500 * time.Millisecond,
 	}
 	options.SetLocalAddrIP("1.2.3.4")
-	err = options.Validate()
-	require.Nil(t, err)
-	client, _ = NewWithOptions(options)
-	_, err = client.QueryMultiple("example.com", []uint16{dns.TypeA})
-	require.NotNil(t, err)
-
-	/** Does not error with valid Local IP **/
-	// options = Options{
-	// 	BaseResolvers: []string{"1.1.1.1:53", "udp:8.8.8.8"},
-	// 	MaxRetries:    3,
-	// }
-	// err = options.SetLocalAddrIPFromNetInterface("en0")
-	// require.Nil(t, err)
-	// err = options.Validate()
-	// require.Nil(t, err)
-	// client, _ = NewWithOptions(options)
-	// _, err = client.QueryMultiple("example.com", []uint16{dns.TypeA})
-	// require.Nil(t, err)
-	// // From current dig result
-	// require.True(t, len(d.A) > 0)
+	require.NoError(t, options.Validate())
+	client, err = NewWithOptions(options)
+	require.NoError(t, err)
+	_, err = client.QueryMultiple(fakeHost, []uint16{dns.TypeA})
+	require.Error(t, err)
 }
 
 func TestConsistentResolve(t *testing.T) {
-	client, _ := New([]string{"8.8.8.8:53", "1.1.1.1:53"}, 5)
+	fr := newFakeResolver(t, dns.RcodeSuccess, arecord(fakeHost, "203.0.113.10"))
+	client, err := New([]string{fr.Addr()}, 5)
+	require.NoError(t, err)
 
-	var last string
 	for i := 0; i < 10; i++ {
-		d, err := client.Resolve("scanme.sh")
-		require.Nil(t, err, "could not resolve dns")
-
-		if last != "" {
-			require.Equal(t, last, d.A[0], "got another data from previous")
-		} else {
-			last = d.A[0]
-		}
+		d, err := client.Resolve(fakeHost)
+		require.NoError(t, err, "could not resolve dns")
+		require.Equal(t, []string{"203.0.113.10"}, d.A, "iteration %d returned different data", i)
 	}
 }
 
 func TestUDP(t *testing.T) {
-	client, _ := New([]string{"1.1.1.1:53", "udp:8.8.8.8"}, 5)
+	fr := newFakeResolver(t, dns.RcodeSuccess, arecord(fakeHost, "203.0.113.10"))
+	client, err := New([]string{"udp:" + fr.Addr()}, 5)
+	require.NoError(t, err)
 
-	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
-	require.Nil(t, err)
-
-	// From current dig result
-	require.True(t, len(d.A) > 0)
+	d, err := client.QueryMultiple(fakeHost, []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.NotEmpty(t, d.A)
 }
 
 func TestTCP(t *testing.T) {
-	client, _ := New([]string{"tcp:1.1.1.1:53", "tcp:8.8.8.8"}, 5)
+	fr := newFakeResolverTCP(t, dns.RcodeSuccess, arecord(fakeHost, "203.0.113.10"))
+	client, err := New([]string{"tcp:" + fr.Addr()}, 5)
+	require.NoError(t, err)
 
-	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
-	require.Nil(t, err)
-
-	// From current dig result
-	require.True(t, len(d.A) > 0)
+	d, err := client.QueryMultiple(fakeHost, []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.NotEmpty(t, d.A)
 }
 
 func TestDOH(t *testing.T) {
-	client, _ := New([]string{"doh:https://doh.opendns.com/dns-query:post", "doh:https://doh.opendns.com/dns-query:get"}, 5)
+	fd := newFakeDoHResolver(t, dns.RcodeSuccess, arecord(fakeHost, "203.0.113.10"))
 
-	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
-	require.Nil(t, err)
-
-	// From current dig result
-	require.True(t, len(d.A) > 0)
+	for _, method := range []string{"post", "get"} {
+		t.Run(method, func(t *testing.T) {
+			client, err := New([]string{fd.ResolverString(method)}, 5)
+			require.NoError(t, err)
+			d, err := client.QueryMultiple(fakeHost, []uint16{dns.TypeA})
+			require.NoError(t, err)
+			require.NotEmpty(t, d.A)
+		})
+	}
 }
 
+// TestDOT is intentionally an integration test against public DoT
+// resolvers because the retryabledns client builds its internal dot
+// client without a configurable *tls.Config, so we can't accept a
+// self-signed cert from an in-process server. It's gated by
+// testing.Short so it stays out of unit-test runs.
 func TestDOT(t *testing.T) {
-	client, _ := New([]string{"dot:dns.google:853", "dot:1dot1dot1dot1.cloudflare-dns.com"}, 5)
-
+	if testing.Short() {
+		t.Skip("DOT test requires real network in -short mode")
+	}
+	client, err := New(
+		[]string{"dot:dns.google:853", "dot:1dot1dot1dot1.cloudflare-dns.com"}, 5,
+	)
+	require.NoError(t, err)
 	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
-	require.Nil(t, err)
-
-	// From current dig result
-	require.True(t, len(d.A) > 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, d.A)
 }
 
 func TestQueryMultiple(t *testing.T) {
-	client, _ := New([]string{"8.8.8.8:53", "1.1.1.1:53"}, 5)
+	fr := newFakeResolverFunc(t, rrByQtype(map[uint16][]dns.RR{
+		dns.TypeA:    {arecord(fakeHost, "203.0.113.10")},
+		dns.TypeAAAA: {aaaarecord(fakeHost, "2001:db8::1")},
+		dns.TypeSOA:  {soarecord(fakeHost)},
+	}))
 
-	// Test various query types
-	d, err := client.QueryMultiple("scanme.sh", []uint16{
+	client, err := New([]string{fr.Addr()}, 5)
+	require.NoError(t, err)
+
+	d, err := client.QueryMultiple(fakeHost, []uint16{
 		dns.TypeA,
 		dns.TypeAAAA,
 		dns.TypeSOA,
 	})
-	require.Nil(t, err)
-
-	// From current dig result
-	require.True(t, len(d.A) > 0)
-	require.True(t, len(d.AAAA) > 0)
-	require.True(t, len(d.SOA) > 0)
+	require.NoError(t, err)
+	require.Equal(t, []string{"203.0.113.10"}, d.A)
+	require.Equal(t, []string{"2001:db8::1"}, d.AAAA)
+	require.Len(t, d.SOA, 1)
 	require.NotZero(t, d.TTL)
 }
 
 func TestRetries(t *testing.T) {
-	client, _ := New([]string{"127.0.0.1"}, 5)
+	dead := freeUDPAddr(t)
+	client, err := New([]string{dead}, 5)
+	require.NoError(t, err)
 
-	// Test that error is returned on max retries, should conn refused 5 times then err
-	_, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
+	// QueryMultiple path: ErrRetriesExceeded after exhausting retries
+	// against an unbound port.
+	_, err = client.QueryMultiple(fakeHost, []uint16{dns.TypeA})
 	require.ErrorIs(t, err, ErrRetriesExceeded)
 
+	// Do() path: same expectation via the raw interface.
 	msg := &dns.Msg{}
 	msg.Id = dns.Id()
 	msg.SetEdns0(4096, false)
-	msg.Question = make([]dns.Question, 1)
-	msg.RecursionDesired = true
-	question := dns.Question{
-		Name:   "scanme.sh",
+	msg.Question = []dns.Question{{
+		Name:   dns.Fqdn(fakeHost),
 		Qtype:  dns.TypeA,
 		Qclass: dns.ClassINET,
-	}
-	msg.Question[0] = question
-
-	// Test with raw Do() interface as well
+	}}
+	msg.RecursionDesired = true
 	_, err = client.Do(msg)
-	require.True(t, err == ErrRetriesExceeded)
+	require.ErrorIs(t, err, ErrRetriesExceeded)
 }
 
 func TestNoRecords(t *testing.T) {
-	client, err := New([]string{"8.8.8.8:53", "1.1.1.1:53"}, 5)
+	// A resolver that answers NOERROR but with no records: the
+	// canonical "host exists but no A/AAAA" path.
+	fr := newFakeResolverFunc(t, rrByQtype(map[uint16][]dns.RR{
+		// No entries: handler returns SUCCESS with empty Answer.
+	}))
+	client, err := New([]string{fr.Addr()}, 5)
 	require.NoError(t, err)
 
-	// Test various query types
-	res, err := client.QueryMultiple("donotexist.scanme.sh", []uint16{
+	res, err := client.QueryMultiple("donotexist."+fakeHost, []uint16{
 		dns.TypeA,
 		dns.TypeAAAA,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res)
-
 	assert.Empty(t, res.A)
 	assert.Empty(t, res.AAAA)
 }
 
+// TestTrace remains a network-dependent integration test: it walks the
+// DNS root servers from RootDNSServersIPv4 and follows referrals,
+// which is not feasible to replicate with a local fake. Guard with
+// testing.Short so unit-test runs stay offline.
 func TestTrace(t *testing.T) {
-	client, _ := New([]string{"8.8.8.8:53", "1.1.1.1:53"}, 5)
-
-	_, err := client.Trace("www.projectdiscovery.io", dns.TypeA, 100)
-	require.Nil(t, err, "could not resolve dns")
+	if testing.Short() {
+		t.Skip("Trace test requires real DNS roots in -short mode")
+	}
+	client, err := New([]string{"8.8.8.8:53", "1.1.1.1:53"}, 5)
+	require.NoError(t, err)
+	_, err = client.Trace("www.projectdiscovery.io", dns.TypeA, 100)
+	require.NoError(t, err)
 }
 
 func TestAXFRWithUDPResolvers(t *testing.T) {
-	// Resolver configured without tcp: prefix defaults to UDP.
-	// AXFR requires TCP, so axfr() must force TCP on fallback resolvers.
-	client, err := New([]string{"81.4.108.41:53"}, 3)
+	// Resolver address configured without a tcp: prefix defaults to
+	// UDP. AXFR is TCP-only, so axfr() must force TCP on the fallback
+	// path - we verify that by starting a TCP-only AXFR server and
+	// passing its address as a plain (UDP-by-default) resolver string.
+	// AXFR protocol requires the zone to start and end with an SOA.
+	records := []dns.RR{
+		soarecord("zonetransfer.test"),
+		arecord("ns1.zonetransfer.test", "203.0.113.1"),
+		arecord("host.zonetransfer.test", "203.0.113.2"),
+		soarecord("zonetransfer.test"),
+	}
+	fr := newFakeAXFRResolver(t, records)
+
+	client, err := New([]string{fr.Addr()}, 3)
 	require.NoError(t, err)
 
-	axfrData, err := client.AXFR("zonetransfer.me")
+	axfrData, err := client.AXFR("zonetransfer.test")
 	require.NoError(t, err)
 	require.NotNil(t, axfrData)
-	require.True(t, len(axfrData.DNSData) > 0, "expected AXFR records but got none")
+	require.NotEmpty(t, axfrData.DNSData, "expected AXFR records but got none")
 
 	var totalRecords int
 	for _, d := range axfrData.DNSData {
 		totalRecords += len(d.AllRecords)
 	}
-	require.True(t, totalRecords > 0, "expected non-empty AXFR records")
+	require.Greater(t, totalRecords, 0, "expected non-empty AXFR records")
 }
 
 func TestParseFromMsgIgnoresExtraAndNsSections(t *testing.T) {
@@ -242,9 +268,11 @@ func TestInternalIPDetectionWithHostsFile(t *testing.T) {
 	CheckInternalIPs = true
 	defer func() { CheckInternalIPs = false }()
 
+	fr := newFakeResolverFunc(t, rrByQtype(nil))
 	options := Options{
-		BaseResolvers: []string{"8.8.8.8:53"},
+		BaseResolvers: []string{fr.Addr()},
 		MaxRetries:    3,
+		Timeout:       500 * time.Millisecond,
 		Hostsfile:     true,
 	}
 
@@ -299,9 +327,11 @@ func TestInternalIPDetectionJSONOutput(t *testing.T) {
 	CheckInternalIPs = true
 	defer func() { CheckInternalIPs = false }()
 
+	fr := newFakeResolverFunc(t, rrByQtype(nil))
 	options := Options{
-		BaseResolvers: []string{"8.8.8.8:53"},
+		BaseResolvers: []string{fr.Addr()},
 		MaxRetries:    3,
+		Timeout:       500 * time.Millisecond,
 		Hostsfile:     true,
 	}
 

--- a/doh/doh_client_test.go
+++ b/doh/doh_client_test.go
@@ -1,18 +1,129 @@
 package doh
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 )
 
+// newFakeDoH starts an httptest TLS server that answers both styles of
+// DoH request used by this package:
+//   - "application/dns-json" (the JSON API used by QueryWithJsonAPI)
+//   - "application/dns-message" (RFC 8484 wire format, GET via ?dns= or POST body)
+//
+// It always returns the provided IPv4 address as a single A record.
+// The returned server's *http.Client trusts the test certificate.
+func newFakeDoH(t *testing.T, ip string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// JSON API path: clients set Accept: application/dns-json and
+		// pass name/type as query params.
+		if strings.Contains(r.Header.Get("Accept"), "application/dns-json") {
+			name := r.URL.Query().Get("name")
+			resp := Response{
+				Status: 0,
+				Question: []Question{{
+					Name: dns.Fqdn(name),
+					Type: int(dns.TypeA),
+				}},
+				Answer: []Answer{{
+					Name: dns.Fqdn(name),
+					Type: int(dns.TypeA),
+					TTL:  60,
+					Data: ip,
+				}},
+			}
+			w.Header().Set("Content-Type", "application/dns-json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// Wire format path: parse the DNS message from either ?dns= or
+		// the body and reply with a single A record.
+		var body []byte
+		var err error
+		switch r.Method {
+		case http.MethodGet:
+			body, err = base64.RawURLEncoding.DecodeString(r.URL.Query().Get("dns"))
+		default:
+			body, err = io.ReadAll(r.Body)
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		req := &dns.Msg{}
+		if err := req.Unpack(body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		name := req.Question[0].Name
+		msg := &dns.Msg{}
+		msg.SetReply(req)
+		msg.Rcode = dns.RcodeSuccess
+		msg.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+				A:   parseIPv4(ip),
+			},
+		}
+		out, err := msg.Pack()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/dns-message")
+		_, _ = w.Write(out)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func parseIPv4(s string) []byte {
+	var ip [4]byte
+	parts := strings.Split(s, ".")
+	if len(parts) != 4 {
+		return nil
+	}
+	for i, p := range parts {
+		var v int
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return nil
+			}
+			v = v*10 + int(c-'0')
+		}
+		if v < 0 || v > 255 {
+			return nil
+		}
+		ip[i] = byte(v)
+	}
+	return ip[:]
+}
+
+func newFakeClient(t *testing.T, ip string) *Client {
+	t.Helper()
+	srv := newFakeDoH(t, ip)
+	return NewWithOptions(Options{
+		DefaultResolver: Resolver{Name: "fake", URL: srv.URL},
+		HttpClient:      srv.Client(),
+	})
+}
+
 func TestConsistentResolve(t *testing.T) {
-	client := New()
+	client := newFakeClient(t, "203.0.113.10")
 	var lastAnswer string
 	for i := 0; i < 10; i++ {
-		d, err := client.Query("scanme.sh", A)
-		require.Nil(t, err, "could not resolve dns")
+		d, err := client.Query("scanme.test", A)
+		require.NoError(t, err, "could not resolve dns")
+		require.NotEmpty(t, d.Answer, "expected at least one answer")
 		if lastAnswer == "" {
 			lastAnswer = d.Answer[0].Data
 		} else {
@@ -22,11 +133,20 @@ func TestConsistentResolve(t *testing.T) {
 }
 
 func TestResolvers(t *testing.T) {
-	client := New()
-	d, err := client.QueryWithDOH(MethodGet, OpenDNS, "www.example.com", dns.TypeA)
-	require.Nil(t, err, "could not resolve dns")
-	require.NotNil(t, d, "could not retrieve data")
-	d, err = client.QueryWithDOH(MethodPost, OpenDNS, "www.example.com", dns.TypeA)
-	require.Nil(t, err, "could not resolve dns")
-	require.NotNil(t, d, "could not retrieve data")
+	srv := newFakeDoH(t, "203.0.113.10")
+	client := NewWithOptions(Options{
+		DefaultResolver: Resolver{Name: "fake", URL: srv.URL},
+		HttpClient:      srv.Client(),
+	})
+	fakeResolver := Resolver{Name: "fake", URL: srv.URL}
+
+	d, err := client.QueryWithDOH(MethodGet, fakeResolver, "www.example.com", dns.TypeA)
+	require.NoError(t, err)
+	require.NotNil(t, d)
+	require.NotEmpty(t, d.Answer, "GET path must return an answer")
+
+	d, err = client.QueryWithDOH(MethodPost, fakeResolver, "www.example.com", dns.TypeA)
+	require.NoError(t, err)
+	require.NotNil(t, d)
+	require.NotEmpty(t, d.Answer, "POST path must return an answer")
 }

--- a/exit_status_test.go
+++ b/exit_status_test.go
@@ -1,0 +1,259 @@
+package retryabledns
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Unit tests for the option's predicate
+// -----------------------------------------------------------------------------
+
+func TestOptions_ExitOnRcode_DefaultsToSuccessOnly(t *testing.T) {
+	var opts Options
+	require.True(t, opts.exitOnRcode(dns.RcodeSuccess),
+		"empty list must still terminate on RcodeSuccess for backward compatibility")
+	require.False(t, opts.exitOnRcode(dns.RcodeNameError),
+		"empty list must not terminate on non-success rcodes")
+	require.False(t, opts.exitOnRcode(dns.RcodeServerFailure))
+	require.False(t, opts.exitOnRcode(dns.RcodeRefused))
+}
+
+func TestOptions_ExitOnRcode_RespectsList(t *testing.T) {
+	opts := Options{ExitOnStatusCodes: []int{dns.RcodeSuccess, dns.RcodeNameError}}
+	require.True(t, opts.exitOnRcode(dns.RcodeSuccess))
+	require.True(t, opts.exitOnRcode(dns.RcodeNameError))
+	require.False(t, opts.exitOnRcode(dns.RcodeServerFailure))
+}
+
+// TestOptions_ExitOnRcode_ListWithoutSuccess proves that an
+// ExitOnStatusCodes list that excludes RcodeSuccess fully overrides the
+// default ("success terminates") - this is a deliberate, documented
+// consequence of treating the list as the source of truth.
+func TestOptions_ExitOnRcode_ListWithoutSuccess(t *testing.T) {
+	opts := Options{ExitOnStatusCodes: []int{dns.RcodeServerFailure}}
+	require.False(t, opts.exitOnRcode(dns.RcodeSuccess))
+	require.True(t, opts.exitOnRcode(dns.RcodeServerFailure))
+}
+
+// -----------------------------------------------------------------------------
+// Legacy-behavior regression suite (Options.ExitOnStatusCodes == nil)
+//
+// These tests pin the historical contract so any future refactor of the
+// retry loop has to keep producing the same observable behavior for
+// callers who have not opted into the new option.
+// -----------------------------------------------------------------------------
+
+func newLegacyClient(t *testing.T, resolvers ...string) *Client {
+	t.Helper()
+	c, err := NewWithOptions(Options{
+		BaseResolvers: resolvers,
+		MaxRetries:    3,
+		Timeout:       500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	return c
+}
+
+func TestLegacy_SuccessOnFirstAttempt(t *testing.T) {
+	ok := newFakeResolver(t, dns.RcodeSuccess, arecord("scanme.sh", "203.0.113.10"))
+	client := newLegacyClient(t, ok.Addr())
+
+	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.Equal(t, []string{"203.0.113.10"}, d.A)
+	require.Equal(t, "NOERROR", d.StatusCode)
+	require.Equal(t, []string{ok.Addr()}, d.Resolver,
+		"resolver list must contain exactly the resolver that answered")
+	require.EqualValues(t, 1, ok.Queries(),
+		"loop must break on the first success and not retry")
+}
+
+func TestLegacy_NxdomainExhaustsRetriesAndAccumulates(t *testing.T) {
+	nx := newFakeResolver(t, dns.RcodeNameError)
+	client := newLegacyClient(t, nx.Addr())
+
+	d, err := client.QueryMultiple("missing.example", []uint16{dns.TypeA})
+	require.NoError(t, err, "legacy path returns nil error even when all attempts are NXDOMAIN")
+	require.Equal(t, "NXDOMAIN", d.StatusCode)
+	require.EqualValues(t, 3, nx.Queries(),
+		"every retry attempt must hit the resolver under legacy semantics")
+	// Legacy semantics: every attempt appends its resolver and
+	// concatenates its raw text into dnsdata.
+	require.Len(t, d.Resolver, 3,
+		"legacy path appends the resolver on every NXDOMAIN attempt")
+	require.GreaterOrEqual(t, strings.Count(d.Raw, "NXDOMAIN"), 2,
+		"legacy path accumulates Raw text from every attempt")
+}
+
+func TestLegacy_NxdomainThenSuccessIsPolluted(t *testing.T) {
+	// Two distinct fake resolvers so dedupe() can't collapse the
+	// Resolver list. The client's internal round-robin uses a
+	// post-incremented index, so with [ok, nx] the first attempt hits
+	// nx (NXDOMAIN, skipped+appended), the second hits ok (SUCCESS).
+	nx := newFakeResolver(t, dns.RcodeNameError)
+	ok := newFakeResolver(t, dns.RcodeSuccess, arecord("scanme.sh", "203.0.113.10"))
+	client := newLegacyClient(t, ok.Addr(), nx.Addr())
+
+	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.Equal(t, []string{"203.0.113.10"}, d.A)
+	// Documenting the current (pre-fix) pollution so a future change
+	// to make this opt-in must be intentional.
+	require.ElementsMatch(t, []string{nx.Addr(), ok.Addr()}, d.Resolver,
+		"legacy path keeps the NXDOMAIN resolver in the list alongside the success one")
+	require.Contains(t, d.Raw, "NXDOMAIN")
+	require.Contains(t, d.Raw, "NOERROR")
+	require.EqualValues(t, 1, nx.Queries())
+	require.EqualValues(t, 1, ok.Queries())
+}
+
+func TestLegacy_DoSurfacesLastNxdomainResponse(t *testing.T) {
+	nx := newFakeResolver(t, dns.RcodeNameError)
+	client := newLegacyClient(t, nx.Addr())
+
+	msg := &dns.Msg{}
+	msg.SetQuestion(dns.Fqdn("missing.example"), dns.TypeA)
+	resp, err := client.Do(msg)
+
+	require.ErrorIs(t, err, ErrRetriesExceeded)
+	require.NotNil(t, resp,
+		"legacy Do must surface the last NXDOMAIN response so callers can inspect the rcode")
+	require.Equal(t, dns.RcodeNameError, resp.Rcode)
+}
+
+// -----------------------------------------------------------------------------
+// New-behavior suite (ExitOnStatusCodes set)
+//
+// All of the cases below would behave differently from the legacy suite
+// above. Together with the legacy tests they prove that the option
+// strictly adds new behavior without altering any existing path.
+// -----------------------------------------------------------------------------
+
+func newExitClient(t *testing.T, exitOn []int, resolvers ...string) *Client {
+	t.Helper()
+	c, err := NewWithOptions(Options{
+		BaseResolvers:     resolvers,
+		MaxRetries:        3,
+		Timeout:           500 * time.Millisecond,
+		ExitOnStatusCodes: exitOn,
+	})
+	require.NoError(t, err)
+	return c
+}
+
+func TestExit_OnlySuccess_NxdomainProducesEmptyData(t *testing.T) {
+	nx := newFakeResolver(t, dns.RcodeNameError)
+	client := newExitClient(t, []int{dns.RcodeSuccess}, nx.Addr())
+
+	d, err := client.QueryMultiple("missing.example", []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.NotNil(t, d)
+	require.Empty(t, d.StatusCode, "non-definitive rcode must not pollute StatusCode")
+	require.Empty(t, d.Resolver, "non-definitive attempts must not append to Resolver")
+	require.Empty(t, d.Raw, "non-definitive attempts must not accumulate Raw text")
+	require.Empty(t, d.A)
+	require.EqualValues(t, 3, nx.Queries(),
+		"loop still runs all retries; only the data path is suppressed")
+}
+
+func TestExit_OnlySuccess_NxdomainThenSuccessRecordsOnlyWinner(t *testing.T) {
+	// Direct contrast against TestLegacy_NxdomainThenSuccessIsPolluted:
+	// same resolver setup, opting into ExitOnStatusCodes makes the
+	// NXDOMAIN attempt invisible in dnsdata.
+	nx := newFakeResolver(t, dns.RcodeNameError)
+	ok := newFakeResolver(t, dns.RcodeSuccess, arecord("scanme.sh", "203.0.113.10"))
+	client := newExitClient(t, []int{dns.RcodeSuccess}, ok.Addr(), nx.Addr())
+
+	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.Equal(t, []string{"203.0.113.10"}, d.A)
+	require.Equal(t, []string{ok.Addr()}, d.Resolver,
+		"only the resolver that returned the definitive rcode must be recorded")
+	require.NotContains(t, d.Raw, "NXDOMAIN",
+		"non-definitive responses must never appear in Raw")
+	require.Contains(t, d.Raw, "NOERROR")
+	require.EqualValues(t, 1, nx.Queries(), "the NXDOMAIN attempt still happens, just isn't recorded")
+	require.EqualValues(t, 1, ok.Queries())
+}
+
+func TestExit_IncludesNxdomain_BreaksOnFirstAttempt(t *testing.T) {
+	nx := newFakeResolver(t, dns.RcodeNameError)
+	client := newExitClient(t, []int{dns.RcodeSuccess, dns.RcodeNameError}, nx.Addr())
+
+	d, err := client.QueryMultiple("missing.example", []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.Equal(t, "NXDOMAIN", d.StatusCode,
+		"NXDOMAIN must be captured when explicitly listed")
+	require.EqualValues(t, 1, nx.Queries(),
+		"loop must break on the first definitive attempt; no extra retries")
+	require.Len(t, d.Resolver, 1)
+}
+
+func TestExit_OnlyServfail_OtherRcodesAreSkipped(t *testing.T) {
+	// First attempt returns NXDOMAIN (skipped), second returns
+	// SERVFAIL (matches the exit list and terminates the loop).
+	var calls atomicCounter
+	fr := newFakeResolverFunc(t, func(req *dns.Msg) *dns.Msg {
+		m := &dns.Msg{}
+		m.SetReply(req)
+		if calls.next() == 1 {
+			m.Rcode = dns.RcodeNameError
+		} else {
+			m.Rcode = dns.RcodeServerFailure
+		}
+		return m
+	})
+	client := newExitClient(t, []int{dns.RcodeServerFailure}, fr.Addr())
+
+	d, err := client.QueryMultiple("anything.example", []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.Equal(t, "SERVFAIL", d.StatusCode,
+		"arbitrary rcodes can be promoted to definitive via ExitOnStatusCodes")
+	require.Len(t, d.Resolver, 1,
+		"only the definitive (SERVFAIL) attempt must appear in the resolver list")
+	require.EqualValues(t, 2, fr.Queries(),
+		"the skipped NXDOMAIN attempt must still happen; SERVFAIL terminates after it")
+}
+
+func TestExit_OnlySuccess_StillSucceedsImmediately(t *testing.T) {
+	ok := newFakeResolver(t, dns.RcodeSuccess, arecord("scanme.sh", "203.0.113.10"))
+	client := newExitClient(t, []int{dns.RcodeSuccess}, ok.Addr())
+
+	d, err := client.QueryMultiple("scanme.sh", []uint16{dns.TypeA})
+	require.NoError(t, err)
+	require.Equal(t, []string{"203.0.113.10"}, d.A)
+	require.EqualValues(t, 1, ok.Queries(),
+		"successful resolution must not trigger extra retries under the new option")
+}
+
+func TestExit_Do_SuppressesTrailingNonDefinitive(t *testing.T) {
+	nx := newFakeResolver(t, dns.RcodeNameError)
+	client := newExitClient(t, []int{dns.RcodeSuccess}, nx.Addr())
+
+	msg := &dns.Msg{}
+	msg.SetQuestion(dns.Fqdn("missing.example"), dns.TypeA)
+	resp, err := client.Do(msg)
+
+	require.ErrorIs(t, err, ErrRetriesExceeded)
+	require.Nil(t, resp,
+		"non-definitive trailing response must be suppressed when ExitOnStatusCodes is set")
+}
+
+func TestExit_Do_ReturnsDefinitiveResponse(t *testing.T) {
+	nx := newFakeResolver(t, dns.RcodeNameError)
+	client := newExitClient(t, []int{dns.RcodeNameError}, nx.Addr())
+
+	msg := &dns.Msg{}
+	msg.SetQuestion(dns.Fqdn("missing.example"), dns.TypeA)
+	resp, err := client.Do(msg)
+
+	require.NoError(t, err,
+		"Do must return success when the rcode is in ExitOnStatusCodes")
+	require.NotNil(t, resp)
+	require.Equal(t, dns.RcodeNameError, resp.Rcode)
+}

--- a/fake_resolver_test.go
+++ b/fake_resolver_test.go
@@ -58,17 +58,6 @@ func newFakeResolverTCP(t *testing.T, rcode int, answer ...dns.RR) *fakeResolver
 	return fr
 }
 
-// newFakeResolverDualStack starts servers on the same address+port for
-// both UDP and TCP. Useful when the test needs to assert that the
-// client picks the right transport.
-func newFakeResolverDualStack(t *testing.T, respond func(*dns.Msg) *dns.Msg) *fakeResolver {
-	t.Helper()
-	fr := &fakeResolver{respond: respond}
-	fr.startUDP(t, "127.0.0.1:0")
-	fr.startTCP(t, fr.addr) // reuse the same address picked by the UDP listener
-	return fr
-}
-
 // newFakeAXFRResolver starts a dual-stack server that handles the
 // full AXFR flow: it answers the NS/A discovery probes over UDP with
 // empty NOERROR (so the client falls back to the originally

--- a/fake_resolver_test.go
+++ b/fake_resolver_test.go
@@ -1,0 +1,320 @@
+package retryabledns
+
+import (
+	"encoding/base64"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeResolver is a tiny in-process DNS server used by the test suite
+// to assert exact retry-loop behavior without depending on the public
+// Internet. Each instance listens on 127.0.0.1 on an ephemeral port
+// and is torn down via t.Cleanup.
+//
+// A single instance can serve UDP, TCP, or both depending on which
+// constructor was used.
+type fakeResolver struct {
+	addr     string
+	udp      *dns.Server
+	tcp      *dns.Server
+	queries  atomic.Int64
+	respond  func(*dns.Msg) *dns.Msg
+	respAxfr func(*dns.Msg) []dns.RR // optional: when set, AXFR queries stream these records
+}
+
+// newFakeResolver starts a UDP server that answers every query with
+// the given rcode. When rcode == RcodeSuccess and answer is non-nil,
+// the records are returned in the Answer section.
+func newFakeResolver(t *testing.T, rcode int, answer ...dns.RR) *fakeResolver {
+	t.Helper()
+	return newFakeResolverFunc(t, fixedResponse(rcode, answer))
+}
+
+// newFakeResolverFunc starts a UDP server with a custom response
+// function. Use it when the test needs to vary the rcode or answer
+// across consecutive queries.
+func newFakeResolverFunc(t *testing.T, respond func(*dns.Msg) *dns.Msg) *fakeResolver {
+	t.Helper()
+	fr := &fakeResolver{respond: respond}
+	fr.startUDP(t, "127.0.0.1:0")
+	return fr
+}
+
+// newFakeResolverTCP starts a TCP-only server. Used to validate the
+// tcp: protocol path of the client.
+func newFakeResolverTCP(t *testing.T, rcode int, answer ...dns.RR) *fakeResolver {
+	t.Helper()
+	fr := &fakeResolver{respond: fixedResponse(rcode, answer)}
+	fr.startTCP(t, "127.0.0.1:0")
+	return fr
+}
+
+// newFakeResolverDualStack starts servers on the same address+port for
+// both UDP and TCP. Useful when the test needs to assert that the
+// client picks the right transport.
+func newFakeResolverDualStack(t *testing.T, respond func(*dns.Msg) *dns.Msg) *fakeResolver {
+	t.Helper()
+	fr := &fakeResolver{respond: respond}
+	fr.startUDP(t, "127.0.0.1:0")
+	fr.startTCP(t, fr.addr) // reuse the same address picked by the UDP listener
+	return fr
+}
+
+// newFakeAXFRResolver starts a dual-stack server that handles the
+// full AXFR flow: it answers the NS/A discovery probes over UDP with
+// empty NOERROR (so the client falls back to the originally
+// configured resolver) and streams the provided records over TCP in
+// response to AXFR queries.
+func newFakeAXFRResolver(t *testing.T, zoneRecords []dns.RR) *fakeResolver {
+	t.Helper()
+	emptySuccess := func(req *dns.Msg) *dns.Msg {
+		m := &dns.Msg{}
+		m.SetReply(req)
+		m.Rcode = dns.RcodeSuccess
+		return m
+	}
+	fr := &fakeResolver{
+		respond:  emptySuccess,
+		respAxfr: func(req *dns.Msg) []dns.RR { return zoneRecords },
+	}
+	fr.startUDP(t, "127.0.0.1:0")
+	fr.startTCP(t, fr.addr)
+	return fr
+}
+
+func (fr *fakeResolver) Addr() string   { return fr.addr }
+func (fr *fakeResolver) Queries() int64 { return fr.queries.Load() }
+
+func (fr *fakeResolver) handle(w dns.ResponseWriter, r *dns.Msg) {
+	fr.queries.Add(1)
+	// AXFR queries get streamed via dns.Transfer when configured.
+	if fr.respAxfr != nil && len(r.Question) > 0 && r.Question[0].Qtype == dns.TypeAXFR {
+		tr := new(dns.Transfer)
+		ch := make(chan *dns.Envelope, 1)
+		ch <- &dns.Envelope{RR: fr.respAxfr(r)}
+		close(ch)
+		_ = tr.Out(w, r, ch)
+		return
+	}
+	_ = w.WriteMsg(fr.respond(r))
+}
+
+func (fr *fakeResolver) startUDP(t *testing.T, addr string) {
+	t.Helper()
+	host, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	p, _ := strconv.Atoi(port)
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP(host), Port: p})
+	require.NoError(t, err)
+	if fr.addr == "" {
+		fr.addr = conn.LocalAddr().String()
+	}
+	fr.udp = &dns.Server{PacketConn: conn, Handler: dns.HandlerFunc(fr.handle)}
+	startServer(t, fr.udp)
+}
+
+func (fr *fakeResolver) startTCP(t *testing.T, addr string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	if fr.addr == "" {
+		fr.addr = ln.Addr().String()
+	}
+	fr.tcp = &dns.Server{Listener: ln, Handler: dns.HandlerFunc(fr.handle)}
+	startServer(t, fr.tcp)
+}
+
+func startServer(t *testing.T, server *dns.Server) {
+	t.Helper()
+	ready := make(chan struct{})
+	server.NotifyStartedFunc = func() { close(ready) }
+	go func() { _ = server.ActivateAndServe() }()
+	<-ready
+	t.Cleanup(func() { _ = server.Shutdown() })
+}
+
+func fixedResponse(rcode int, answer []dns.RR) func(*dns.Msg) *dns.Msg {
+	return func(req *dns.Msg) *dns.Msg {
+		m := &dns.Msg{}
+		m.SetReply(req)
+		m.Rcode = rcode
+		if rcode == dns.RcodeSuccess && len(answer) > 0 {
+			m.Answer = answer
+		}
+		return m
+	}
+}
+
+// atomicCounter is a tiny helper for tests that need to drive a fake
+// resolver through a deterministic sequence of responses based on the
+// number of queries it has already answered.
+type atomicCounter struct{ n atomic.Int64 }
+
+func (c *atomicCounter) next() int64 { return c.n.Add(1) }
+
+// arecord builds an A record matching how miekg/dns formats answers.
+// Used as the Answer section of synthetic success responses.
+func arecord(name, ip string) *dns.A {
+	return &dns.A{
+		Hdr: dns.RR_Header{
+			Name:   dns.Fqdn(name),
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    60,
+		},
+		A: net.ParseIP(ip).To4(),
+	}
+}
+
+// aaaarecord builds an AAAA record for synthetic success responses.
+func aaaarecord(name, ip string) *dns.AAAA {
+	return &dns.AAAA{
+		Hdr: dns.RR_Header{
+			Name:   dns.Fqdn(name),
+			Rrtype: dns.TypeAAAA,
+			Class:  dns.ClassINET,
+			Ttl:    60,
+		},
+		AAAA: net.ParseIP(ip),
+	}
+}
+
+// soarecord builds a synthetic SOA for tests that exercise TypeSOA.
+// The Ns and Mbox fields must be fully qualified, otherwise the
+// miekg/dns packer silently produces a malformed response that the
+// client cannot read.
+func soarecord(name string) *dns.SOA {
+	return &dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   dns.Fqdn(name),
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassINET,
+			Ttl:    3600,
+		},
+		Ns:      dns.Fqdn("ns1." + name),
+		Mbox:    dns.Fqdn("admin." + name),
+		Serial:  2024010101,
+		Refresh: 7200,
+		Retry:   3600,
+		Expire:  1209600,
+		Minttl:  300,
+	}
+}
+
+// rrByQtype dispatches to a per-rrtype response factory. It's the
+// canonical way to model a server that answers multiple query types
+// from the same address.
+func rrByQtype(answers map[uint16][]dns.RR) func(*dns.Msg) *dns.Msg {
+	return func(req *dns.Msg) *dns.Msg {
+		m := &dns.Msg{}
+		m.SetReply(req)
+		if len(req.Question) == 0 {
+			return m
+		}
+		qt := req.Question[0].Qtype
+		records, ok := answers[qt]
+		if !ok {
+			// Mirror the behavior of a real resolver: success rcode
+			// with an empty answer section when no records exist for
+			// this type.
+			m.Rcode = dns.RcodeSuccess
+			return m
+		}
+		m.Rcode = dns.RcodeSuccess
+		m.Answer = records
+		return m
+	}
+}
+
+// freeUDPAddr returns a 127.0.0.1 UDP port that nothing is bound to
+// (the listener is opened and immediately closed). It's used to test
+// the "connection refused" / "no resolver" retry paths without
+// depending on a real network destination.
+func freeUDPAddr(t *testing.T) string {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	require.NoError(t, err)
+	addr := conn.LocalAddr().String()
+	require.NoError(t, conn.Close())
+	return addr
+}
+
+// -----------------------------------------------------------------------------
+// DoH fake server
+// -----------------------------------------------------------------------------
+
+// fakeDoHResolver is a tiny in-process DoH endpoint backed by
+// httptest.NewTLSServer. The retryabledns DoH client is built with
+// InsecureSkipVerify, so the self-signed cert is accepted out of the
+// box.
+type fakeDoHResolver struct {
+	srv     *httptest.Server
+	queries atomic.Int64
+}
+
+func newFakeDoHResolver(t *testing.T, rcode int, answer ...dns.RR) *fakeDoHResolver {
+	t.Helper()
+	fd := &fakeDoHResolver{}
+	fd.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fd.queries.Add(1)
+		body, err := readDoHQuery(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		req := &dns.Msg{}
+		if err := req.Unpack(body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp := &dns.Msg{}
+		resp.SetReply(req)
+		resp.Rcode = rcode
+		if rcode == dns.RcodeSuccess && len(answer) > 0 {
+			resp.Answer = answer
+		}
+		out, err := resp.Pack()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/dns-message")
+		_, _ = w.Write(out)
+	}))
+	t.Cleanup(fd.srv.Close)
+	return fd
+}
+
+// ResolverString returns the resolver string in the form expected by
+// retryabledns ("doh:<url>:<method>"). method must be one of
+// "post" / "get" / "jsonapi".
+func (fd *fakeDoHResolver) ResolverString(method string) string {
+	return "doh:" + fd.srv.URL + "/dns-query:" + method
+}
+
+// HostPort returns the host:port of the underlying HTTPS server, used
+// when we need it bare (without the doh: prefix).
+func (fd *fakeDoHResolver) HostPort() string {
+	u, _ := url.Parse(fd.srv.URL)
+	return u.Host
+}
+
+func (fd *fakeDoHResolver) Queries() int64 { return fd.queries.Load() }
+
+func readDoHQuery(r *http.Request) ([]byte, error) {
+	switch r.Method {
+	case http.MethodGet:
+		return base64.RawURLEncoding.DecodeString(r.URL.Query().Get("dns"))
+	default:
+		return io.ReadAll(r.Body)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -34,6 +34,40 @@ type Options struct {
 	ConnectionPoolThreads int
 	MaxPerCNAMEFollows    int
 	Proxy                 string
+
+	// ExitOnStatusCodes lists DNS rcodes that terminate the retry
+	// loop. When non-empty, only attempts whose rcode is in this list
+	// are considered definitive: the response is parsed into the
+	// returned DNSData and the loop exits. Attempts with any other
+	// rcode are treated like transport errors - the response is not
+	// parsed, DNSData is not mutated, and the loop continues with the
+	// next resolver.
+	//
+	// Common values:
+	//
+	//	[]int{dns.RcodeSuccess}                       // NOERROR only
+	//	[]int{dns.RcodeSuccess, dns.RcodeNameError}   // NOERROR or NXDOMAIN
+	//
+	// An empty/nil list preserves the legacy behavior: every attempt
+	// is parsed, DNSData.Raw accumulates across retries, and only
+	// RcodeSuccess breaks the loop.
+	ExitOnStatusCodes []int
+}
+
+// exitOnRcode reports whether rcode is one of the configured
+// terminating status codes. It returns true when no list is set so the
+// historical "break on success" path keeps working unchanged at the
+// call sites that gate on it.
+func (options *Options) exitOnRcode(rcode int) bool {
+	if len(options.ExitOnStatusCodes) == 0 {
+		return rcode == 0 // dns.RcodeSuccess
+	}
+	for _, c := range options.ExitOnStatusCodes {
+		if c == rcode {
+			return true
+		}
+	}
+	return false
 }
 
 // Returns a net.Addr of a UDP or TCP type depending on whats required


### PR DESCRIPTION
Closes #250.

Opt-in via Options.ExitOnStatusCodes. Empty = unchanged behavior.

Also converts the test suite to local fakes; unit runs are now offline.