### PR TITLE
proxy leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -210,7 +210,21 @@ func (c *Client) Resolve(host string) (*DNSData, error) {
 func (c *Client) Do(msg *dns.Msg) (*dns.Msg, error) {
 	var resp *dns.Msg
 	var err error
+	// activeConn holds the proxied connection dialed for the current attempt.
+	// It is closed at the top of the next iteration (and via defer on return) so
+	// that retries cannot accumulate open connections: a deferred Close inside
+	// the loop only fires when Do returns, leaking one socket per retry.
+	var activeConn *dns.Conn
+	defer func() {
+		if activeConn != nil {
+			_ = activeConn.Close()
+		}
+	}()
 	for i := 0; i < c.options.MaxRetries; i++ {
+		if activeConn != nil {
+			_ = activeConn.Close()
+			activeConn = nil
+		}
 		index := atomic.AddUint32(&c.serversIndex, 1)
 		resolver := c.resolvers[index%uint32(len(c.resolvers))]
 
@@ -224,7 +238,7 @@ func (c *Client) Do(msg *dns.Msg) (*dns.Msg, error) {
 					if err != nil {
 						break
 					}
-					defer tcpConn.Close()
+					activeConn = tcpConn
 					resp, _, err = c.tcpClient.ExchangeWithConn(msg, tcpConn)
 				} else {
 					resp, _, err = c.tcpClient.Exchange(msg, resolver.String())
@@ -240,7 +254,7 @@ func (c *Client) Do(msg *dns.Msg) (*dns.Msg, error) {
 					if err != nil {
 						break
 					}
-					defer udpConn.Close()
+					activeConn = udpConn
 					resp, _, err = c.udpClient.ExchangeWithConn(msg, udpConn)
 				} else {
 					resp, _, err = c.udpClient.Exchange(msg, resolver.String())
@@ -358,7 +372,18 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 		hasResolver bool = resolver != nil
 		dnsdata     DNSData
 		err         error
+		// activeConn holds the connection dialed for the current attempt (proxy
+		// or AXFR). It is closed at the top of the next iteration and via defer
+		// on return, capping concurrent connections at one. A deferred Close
+		// inside the loop only fires when queryMultiple returns, so it would
+		// leak one socket per retry and per request type.
+		activeConn *dns.Conn
 	)
+	defer func() {
+		if activeConn != nil {
+			_ = activeConn.Close()
+		}
+	}()
 
 	// integrate data with known hosts in case
 	if c.options.Hostsfile {
@@ -425,6 +450,10 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 			i      int
 		)
 		for i = 0; i < c.options.MaxRetries; i++ {
+			if activeConn != nil {
+				_ = activeConn.Close()
+				activeConn = nil
+			}
 			index := atomic.AddUint32(&c.serversIndex, 1)
 			if !hasResolver {
 				resolver = c.resolvers[index%uint32(len(c.resolvers))]
@@ -446,7 +475,7 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 					if err != nil {
 						break
 					}
-					defer dnsconn.Close()
+					activeConn = dnsconn
 					dnsTransfer := &dns.Transfer{Conn: dnsconn}
 					trResp, err = dnsTransfer.In(msg, resolver.String())
 				} else {
@@ -458,7 +487,7 @@ func (c *Client) queryMultiple(host string, requestTypes []uint16, resolver Reso
 							if err != nil {
 								break
 							}
-							defer tcpConn.Close()
+							activeConn = tcpConn
 							resp, _, err = c.tcpClient.ExchangeWithConn(msg, tcpConn)
 						} else {
 							resp, _, err = c.tcpClient.Exchange(msg, resolver.String())

--- a/proxy_leak_test.go
+++ b/proxy_leak_test.go
@@ -1,0 +1,115 @@
+package retryabledns
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/proxy"
+)
+
+// countingDialer is a proxy.Dialer that hands out fake connections while
+// tracking how many are open simultaneously. It lets the proxy retry paths be
+// exercised without a real SOCKS server.
+type countingDialer struct {
+	mu         sync.Mutex
+	live       int
+	total      int
+	maxConcurr int
+}
+
+func (d *countingDialer) Dial(network, addr string) (net.Conn, error) {
+	d.mu.Lock()
+	d.live++
+	d.total++
+	if d.live > d.maxConcurr {
+		d.maxConcurr = d.live
+	}
+	d.mu.Unlock()
+	return &fakeConn{d: d}, nil
+}
+
+func (d *countingDialer) snapshot() (live, total, maxConcurr int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.live, d.total, d.maxConcurr
+}
+
+// fakeConn satisfies net.Conn. Reads fail immediately so each DNS exchange
+// errors quickly and the client retries; Close decrements the live counter and
+// is safe to call more than once.
+type fakeConn struct {
+	d      *countingDialer
+	closed bool
+}
+
+func (c *fakeConn) Read(b []byte) (int, error)  { return 0, io.ErrUnexpectedEOF }
+func (c *fakeConn) Write(b []byte) (int, error) { return len(b), nil }
+func (c *fakeConn) Close() error {
+	c.d.mu.Lock()
+	defer c.d.mu.Unlock()
+	if !c.closed {
+		c.closed = true
+		c.d.live--
+	}
+	return nil
+}
+func (c *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (c *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+func (c *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func newProxyTestClient(t *testing.T, d proxy.Dialer, maxRetries int) *Client {
+	t.Helper()
+	client, err := NewWithOptions(Options{
+		BaseResolvers: []string{"tcp:127.0.0.1:53"},
+		MaxRetries:    maxRetries,
+		Timeout:       time.Second,
+	})
+	require.NoError(t, err)
+	// inject the proxy dialer so the proxied TCP paths are taken
+	client.tcpProxy = d
+	client.resolvers = []Resolver{&NetworkResolver{Protocol: TCP, Host: "127.0.0.1", Port: "53"}}
+	return client
+}
+
+// TestDoProxyNoConnLeak ensures Do closes each proxied connection before the
+// next retry instead of deferring every Close to function return (which leaked
+// one socket per retry).
+func TestDoProxyNoConnLeak(t *testing.T) {
+	const maxRetries = 5
+	d := &countingDialer{}
+	client := newProxyTestClient(t, d, maxRetries)
+
+	msg := &dns.Msg{}
+	msg.SetQuestion(dns.Fqdn("example.com"), dns.TypeA)
+	_, _ = client.Do(msg)
+
+	live, total, maxConcurr := d.snapshot()
+	require.Equal(t, 0, live, "every proxied connection must be closed")
+	require.Equal(t, maxRetries, total, "each retry should dial exactly once")
+	require.LessOrEqual(t, maxConcurr, 1, "at most one proxied connection may be open at a time")
+}
+
+// TestQueryMultipleProxyNoConnLeak ensures the enriched query path also caps
+// concurrent proxied connections at one across retries and request types.
+func TestQueryMultipleProxyNoConnLeak(t *testing.T) {
+	const maxRetries = 4
+	d := &countingDialer{}
+	client := newProxyTestClient(t, d, maxRetries)
+
+	_, _ = client.QueryMultiple("example.com", []uint16{dns.TypeA, dns.TypeAAAA})
+
+	live, total, maxConcurr := d.snapshot()
+	require.Equal(t, 0, live, "every proxied connection must be closed")
+	// The first request type exhausts its retries and the outer loop bails with
+	// ErrRetriesExceeded, so exactly maxRetries dials occur; the key invariant is
+	// that they never pile up.
+	require.Equal(t, maxRetries, total, "each retry should dial exactly once")
+	require.LessOrEqual(t, maxConcurr, 1, "at most one proxied connection may be open at a time")
+}


### PR DESCRIPTION
Close each proxied and AXFR connection before the next retry so retries no longer pile up open sockets until the whole query returns.

Closes #290